### PR TITLE
Update API routing for backend prefix

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,8 +5,17 @@
 {$DOMAIN} {
     encode zstd gzip
 
-    @api path /api* /actuator* /swagger-ui* /v3/*
-    reverse_proxy @api backend:8080
+    @backend_api path /backend-api/*
+    handle @backend_api {
+        uri strip_prefix /backend-api
+        reverse_proxy backend:8080
+    }
+
+    @backend_extra path /actuator* /swagger-ui* /v3/*
+    reverse_proxy @backend_extra backend:8080
+
+    @frontend_api path /api*
+    reverse_proxy @frontend_api frontend:3000
 
     reverse_proxy frontend:3000
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       dockerfile: ../docker/frontend.Dockerfile
     restart: always
     environment:
-      - NEXT_PUBLIC_API_BASE=/api
+      - NEXT_PUBLIC_BACKEND_BASE=/backend-api
       - PORT=3000
     expose: ["3000"]
     depends_on: [ backend ]

--- a/vibe-jobs-view/app/page.tsx
+++ b/vibe-jobs-view/app/page.tsx
@@ -7,17 +7,19 @@ import { useI18n } from '@/lib/i18n';
 import type { Job, JobDetail as JobDetailData, JobsResponse } from '@/lib/types';
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 
+const API_BASE = process.env.NEXT_PUBLIC_BACKEND_BASE ?? '/api';
+
 async function fetchJobs(params: Record<string, any>): Promise<JobsResponse> {
   const qs = new URLSearchParams(
     Object.entries(params).filter(([, v]) => v !== '' && v !== undefined && v !== null) as any,
   );
-  const res = await fetch('/api/jobs?' + qs.toString(), { cache: 'no-store' });
+  const res = await fetch(`${API_BASE}/jobs?` + qs.toString(), { cache: 'no-store' });
   if (!res.ok) throw new Error('Failed to fetch jobs');
   return res.json();
 }
 
 async function fetchJobDetail(id: string): Promise<JobDetailData> {
-  const res = await fetch(`/api/jobs/${id}/detail`, { cache: 'no-store' });
+  const res = await fetch(`${API_BASE}/jobs/${id}/detail`, { cache: 'no-store' });
   if (!res.ok) throw new Error('Failed to fetch job detail');
   const detail = await res.json();
   return {
@@ -481,7 +483,7 @@ export default function Page() {
   const handleConfirmSubscription = async () => {
     setShowSubscriptionModal(false);
     setSubscriptionTrigger(null);
-    await fetch('/api/subscription', {
+    await fetch(`${API_BASE}/subscription`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(subscriptionParams),


### PR DESCRIPTION
## Summary
- update the Caddy proxy to route /api/* to the Next.js frontend and add a /backend-api/* prefix for the backend service
- make the frontend API calls respect a configurable NEXT_PUBLIC_BACKEND_BASE environment variable
- configure the production frontend container to expose NEXT_PUBLIC_BACKEND_BASE=/backend-api

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8b47874e48328b991d6463fac0144