### PR TITLE
Configure frontend backend base URL for containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     restart: always
     environment:
       - NEXT_PUBLIC_BACKEND_BASE=/backend-api
+      - BACKEND_BASE_URL=http://backend:8080
       - PORT=3000
     expose: ["3000"]
     depends_on: [ backend ]

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -19,7 +19,10 @@ RUN npm i -g pnpm && \
 
 FROM node:20-alpine
 WORKDIR /app
-ENV NODE_ENV=production PORT=3000 NEXT_TELEMETRY_DISABLED=1
+ENV NODE_ENV=production \
+    PORT=3000 \
+    NEXT_TELEMETRY_DISABLED=1 \
+    BACKEND_BASE_URL=http://backend:8080
 # ⬇️ 三个必须复制：standalone、static、public
 COPY --from=build /app/.next/standalone ./
 COPY --from=build /app/.next/static ./.next/static

--- a/vibe-jobs-view/README.md
+++ b/vibe-jobs-view/README.md
@@ -20,6 +20,9 @@ Set `BACKEND_BASE_URL` so `/api/jobs` will proxy to your backend's `/api/jobs` e
 ```bash
 BACKEND_BASE_URL="http://localhost:8080" pnpm dev
 ```
+When running inside Docker (or any environment where the Java service is available as `backend:8080`),
+set `BACKEND_BASE_URL="http://backend:8080"` so the Next.js API routes can call it directly over the
+container network.
 Your `/api/jobs` endpoint should accept query params like: `q, company, location, level, page, size` and return:
 ```json
 {


### PR DESCRIPTION
## Summary
- add BACKEND_BASE_URL to the frontend service so the Next.js API can contact the backend over the container network
- bake the same default into the frontend runtime image and document the container hostname in the README

## Testing
- not run (environment does not provide Docker)


------
https://chatgpt.com/codex/tasks/task_e_68d8c3595e2c832884c44237cb3c2d00