### PR TITLE
chore: reset frontend api base to default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       dockerfile: ../docker/frontend.Dockerfile
     restart: always
     environment:
-      - NEXT_PUBLIC_BACKEND_BASE=/backend-api
+      - NEXT_PUBLIC_BACKEND_BASE=/api
       - PORT=3000
     expose: ["3000"]
     depends_on: [ backend ]


### PR DESCRIPTION
## Summary
- point the frontend container configuration back to the default /api base so Next.js serves API routes

## Testing
- docker compose build frontend *(fails: docker not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8c3579fac8328bcaba5edd0aaabee