### PR TITLE
Fix backend base detection for jobs API routes

### DIFF
--- a/vibe-jobs-view/app/api/jobs/[id]/detail/route.ts
+++ b/vibe-jobs-view/app/api/jobs/[id]/detail/route.ts
@@ -13,9 +13,26 @@ function buildBackendUrl(base: string, path: string) {
   return url;
 }
 
+function resolveBackendBase(): string | null {
+  const runtimeBase = process.env['BACKEND_BASE_URL'];
+  if (runtimeBase && runtimeBase.trim()) {
+    return runtimeBase.trim();
+  }
+
+  const publicBase = process.env['NEXT_PUBLIC_BACKEND_BASE'];
+  if (publicBase) {
+    const trimmed = publicBase.trim();
+    if (trimmed && /^(https?:)?\/\//.test(trimmed)) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
 export async function GET(_req: NextRequest, { params }: Params) {
   const { id } = params;
-  const base = process.env.BACKEND_BASE_URL;
+  const base = resolveBackendBase();
 
   if (base) {
     const upstream = buildBackendUrl(base, `/jobs/${id}/detail`);

--- a/vibe-jobs-view/app/api/jobs/route.ts
+++ b/vibe-jobs-view/app/api/jobs/route.ts
@@ -38,6 +38,23 @@ function buildBackendUrl(base: string, path: string) {
   return url;
 }
 
+function resolveBackendBase(): string | null {
+  const runtimeBase = process.env['BACKEND_BASE_URL'];
+  if (runtimeBase && runtimeBase.trim()) {
+    return runtimeBase.trim();
+  }
+
+  const publicBase = process.env['NEXT_PUBLIC_BACKEND_BASE'];
+  if (publicBase) {
+    const trimmed = publicBase.trim();
+    if (trimmed && /^(https?:)?\/\//.test(trimmed)) {
+      return trimmed;
+    }
+  }
+
+  return null;
+}
+
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const q = url.searchParams.get('q')?.toLowerCase() ?? '';
@@ -64,7 +81,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid cursor' }, { status: 400 });
   }
 
-  const base = process.env.BACKEND_BASE_URL;
+  const base = resolveBackendBase();
   if (base) {
     const upstream = buildBackendUrl(base, '/jobs');
     for (const [k, v] of url.searchParams.entries()) upstream.searchParams.set(k, v);


### PR DESCRIPTION
## Summary
- resolve the backend base URL for jobs API routes at runtime instead of relying solely on build-time envs
- fall back to public backend env var when it points to an absolute URL so production can proxy real data

## Testing
- pnpm lint *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d8d18729b08328af7b0a48a202422b