### PR TITLE
Use corepack-managed pnpm in frontend build

### DIFF
--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -1,8 +1,10 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json pnpm-lock.yaml* yarn.lock* package-lock.json* ./
-RUN npm i -g pnpm && \
-    if [ -f pnpm-lock.yaml ]; then pnpm i --frozen-lockfile; \
+RUN corepack enable pnpm \
+    && corepack prepare pnpm@9.10.0 --activate \
+    && pnpm --version \
+    && if [ -f pnpm-lock.yaml ]; then pnpm install --frozen-lockfile; \
     elif [ -f yarn.lock ]; then yarn --frozen-lockfile; \
     else npm ci; fi
 
@@ -12,8 +14,10 @@ COPY . .
 # 复用依赖，保证有 next 可执行
 COPY --from=deps /app/node_modules ./node_modules
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN npm i -g pnpm && \
-    if [ -f pnpm-lock.yaml ]; then pnpm run build; \
+RUN corepack enable pnpm \
+    && corepack prepare pnpm@9.10.0 --activate \
+    && pnpm --version \
+    && if [ -f pnpm-lock.yaml ]; then pnpm run build; \
     elif [ -f yarn.lock ]; then yarn build; \
     else npm run build; fi
 

--- a/vibe-jobs-view/package.json
+++ b/vibe-jobs-view/package.json
@@ -24,5 +24,6 @@
     "postcss": "8.4.47",
     "tailwindcss": "3.4.10",
     "typescript": "5.6.2"
-  }
+  },
+  "packageManager": "pnpm@9.10.0"
 }


### PR DESCRIPTION
## Summary
- declare pnpm 9.10.0 as the workspace package manager
- switch frontend Docker build steps to use corepack-managed pnpm commands

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f986c7a88328a7c994554f61662c