### PR TITLE
Improve Workday session warm-up and browser cookies

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/WorkdaySourceClient.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/WorkdaySourceClient.java
@@ -14,6 +14,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import reactor.core.publisher.Mono;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +45,7 @@ public class WorkdaySourceClient implements SourceClient {
 
     private final String company;
     private final String baseUrl;       // e.g. https://micron.wd1.myworkdayjobs.com
+    private final String origin;        // e.g. https://micron.wd1.myworkdayjobs.com (no path component)
     private final String tenant;        // e.g. micron
     private final String initialSite;   // e.g. External / careers / ...
     private final AtomicReference<String> activeSite;
@@ -56,6 +59,7 @@ public class WorkdaySourceClient implements SourceClient {
     public WorkdaySourceClient(String company, String baseUrl, String tenant, String site) {
         this.company = company;
         this.baseUrl = trimTrailingSlash(baseUrl);
+        this.origin = deriveOrigin(this.baseUrl);
         this.tenant = tenant;
         this.initialSite = site == null ? "" : site.trim();
         this.activeSite = new AtomicReference<>(this.initialSite);
@@ -67,11 +71,13 @@ public class WorkdaySourceClient implements SourceClient {
                 .defaultHeader(HttpHeaders.USER_AGENT, desktopUserAgent())
                 .defaultHeader(HttpHeaders.ACCEPT_LANGUAGE, "en-US,en;q=0.9")
                 .defaultHeader(HttpHeaders.REFERER, buildReferer(this.baseUrl, this.initialSite))
-                .defaultHeader("Origin", this.baseUrl)
+                .defaultHeader("Origin", this.origin)
                 .defaultHeader("X-Workday-Client", "Workday Web Client") // ✅ 正确头
                 .defaultHeader("X-Requested-With", "XMLHttpRequest")     // 避免部分租户反爬
                 .filter(sessionCookies())
                 .build();
+
+        seedBrowserCookies();
     }
 
     @Override
@@ -213,8 +219,36 @@ public class WorkdaySourceClient implements SourceClient {
 
     private String buildReferer(String baseUrl, String site) {
         if (baseUrl == null || baseUrl.isBlank()) return "";
+        String normalized = trimTrailingSlash(baseUrl);
         String s = site == null ? "" : site.trim();
-        return s.isEmpty() ? baseUrl : baseUrl + "/" + s;
+        if (s.isEmpty()) {
+            return normalized;
+        }
+        if (normalized.endsWith("/" + s)) {
+            return normalized;
+        }
+        return normalized + "/" + s;
+    }
+
+    private String deriveOrigin(String url) {
+        if (url == null || url.isBlank()) {
+            return "";
+        }
+        try {
+            java.net.URI uri = java.net.URI.create(url);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if (scheme == null || host == null) {
+                return trimTrailingSlash(url);
+            }
+            int port = uri.getPort();
+            if (port == -1) {
+                return scheme + "://" + host;
+            }
+            return scheme + "://" + host + ":" + port;
+        } catch (IllegalArgumentException ex) {
+            return trimTrailingSlash(url);
+        }
     }
 
     /** 仅在 facet key 合法且 value 非空时才下发；不发 utm_source/空数组。 */
@@ -300,6 +334,9 @@ public class WorkdaySourceClient implements SourceClient {
 
     private String buildPath(String site) {
         String s = (site == null || site.isBlank()) ? "" : site.trim();
+        if (s.isEmpty()) {
+            return "/wday/cxs/" + tenant + "/jobs";
+        }
         return "/wday/cxs/" + tenant + "/" + s + "/jobs";
     }
 
@@ -365,29 +402,57 @@ public class WorkdaySourceClient implements SourceClient {
     /** 预热：GET 一次拿 cookie/CSRF；使用当前 activeSite */
     private void ensureSession() {
         if (initialized.compareAndSet(false, true)) {
-            String path = buildPath(activeSite.get());
-            try {
-                client.get()
-                        .uri(uriBuilder -> uriBuilder
-                                .path(path)
-                                .queryParam("limit", 1)
-                                .queryParam("offset", 0)
-                                .build())
-                        .accept(MediaType.APPLICATION_JSON)
-                        .retrieve()
-                        .toBodilessEntity()
-                        .onErrorResume(WebClientResponseException.class, ex -> {
-                            log.debug("Warm-up GET ignored: {} body={}", ex.getStatusCode(), safeBody(ex));
-                            return Mono.empty();
-                        })
-                        .onErrorResume(t -> {
-                            log.debug("Warm-up GET ignored: {}", t.toString());
-                            return Mono.empty();
-                        })
-                        .block();
-            } catch (Exception e) {
-                log.debug("Warm-up GET threw but continues: {}", e.toString());
-            }
+            String site = activeSite.get();
+            warmUpLandingPage(site);
+            warmUpApiSession(site);
+        }
+    }
+
+    private void warmUpLandingPage(String site) {
+        String landing = landingPath(site);
+        try {
+            client.get()
+                    .uri(landing)
+                    .accept(MediaType.TEXT_HTML)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .onErrorResume(WebClientResponseException.class, ex -> {
+                        log.debug("Landing warm-up ignored: {} body={}", ex.getStatusCode(), safeBody(ex));
+                        return Mono.empty();
+                    })
+                    .onErrorResume(t -> {
+                        log.debug("Landing warm-up ignored: {}", t.toString());
+                        return Mono.empty();
+                    })
+                    .block();
+        } catch (Exception e) {
+            log.debug("Landing warm-up threw but continues: {}", e.toString());
+        }
+    }
+
+    private void warmUpApiSession(String site) {
+        String path = buildPath(site);
+        try {
+            client.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(path)
+                            .queryParam("limit", 1)
+                            .queryParam("offset", 0)
+                            .build())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .onErrorResume(WebClientResponseException.class, ex -> {
+                        log.debug("Warm-up GET ignored: {} body={}", ex.getStatusCode(), safeBody(ex));
+                        return Mono.empty();
+                    })
+                    .onErrorResume(t -> {
+                        log.debug("Warm-up GET ignored: {}", t.toString());
+                        return Mono.empty();
+                    })
+                    .block();
+        } catch (Exception e) {
+            log.debug("Warm-up GET threw but continues: {}", e.toString());
         }
     }
 
@@ -415,5 +480,31 @@ public class WorkdaySourceClient implements SourceClient {
             }
         });
         return Mono.empty();
+    }
+
+    private void seedBrowserCookies() {
+        cookieStore.putIfAbsent("wd-browser-id", UUID.randomUUID().toString());
+        cookieStore.putIfAbsent("timezoneOffset", computeTimezoneOffsetCookie());
+    }
+
+    private String computeTimezoneOffsetCookie() {
+        try {
+            ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+            int minutes = now.getOffset().getTotalSeconds() / 60;
+            return Integer.toString(minutes);
+        } catch (Exception e) {
+            return "0";
+        }
+    }
+
+    private String landingPath(String site) {
+        String s = site == null ? "" : site.trim();
+        if (s.isEmpty()) {
+            return "/";
+        }
+        if (s.startsWith("/")) {
+            return s;
+        }
+        return "/" + s;
     }
 }


### PR DESCRIPTION
## Summary
- warm the Workday session by fetching the tenant's landing page before calling the API so required cookies are issued
- seed synthetic browser-side cookies (wd-browser-id, timezoneOffset) so the POST payload matches a real browser session
- add helpers for computing the timezone offset cookie and resolving landing paths used during warm-up

## Testing
- mvn test *(fails: parent POM download blocked with HTTP 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d95ed51b048328850b5476312a140a