### PR TITLE
Add SMTP email sender for login verification codes

### DIFF
--- a/vibe-jobs-aggregator/README.md
+++ b/vibe-jobs-aggregator/README.md
@@ -66,6 +66,31 @@ mvn spring-boot:run
 
 `CareersApiStartupRunner` logs the number of jobs fetched from each source marked `runOnStartup=true`. The `JobIngestionScheduler` reuses the same configuration for recurring updates.
 
+### Email verification
+
+To deliver login verification codes, configure an SMTP server using Spring Boot's mail settings and provide a sender address:
+
+```yaml
+spring:
+  mail:
+    host: smtp.example.com
+    port: 587
+    username: your-smtp-username
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+auth:
+  email:
+    senderAddress: no-reply@example.com
+```
+
+If no SMTP configuration is supplied, the application falls back to logging verification codes to the console.
+
 ## Notes
 - Greenhouse does not return `postedAt`; we stamp the current time. Extend `GreenhouseSourceClient` if you need more metadata.
 - Lever timestamps are provided in epoch milliseconds and are normalised to `Instant`.

--- a/vibe-jobs-aggregator/pom.xml
+++ b/vibe-jobs-aggregator/pom.xml
@@ -23,6 +23,10 @@
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-web</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-webflux</artifactId></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-data-jpa</artifactId></dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
     <dependency><groupId>com.h2database</groupId><artifactId>h2</artifactId><scope>runtime</scope></dependency>
     <dependency><groupId>org.jsoup</groupId><artifactId>jsoup</artifactId><version>1.17.2</version></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/config/EmailAuthProperties.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/config/EmailAuthProperties.java
@@ -26,6 +26,12 @@ public class EmailAuthProperties {
      */
     private boolean exposeCodeInResponse = false;
 
+    /**
+     * Email address used as the sender when dispatching verification codes via SMTP.
+     * Falls back to {@code spring.mail.username} when left blank.
+     */
+    private String senderAddress;
+
     public Duration getChallengeTtl() {
         return challengeTtl;
     }
@@ -56,5 +62,13 @@ public class EmailAuthProperties {
 
     public void setSessionTtl(Duration sessionTtl) {
         this.sessionTtl = sessionTtl;
+    }
+
+    public String getSenderAddress() {
+        return senderAddress;
+    }
+
+    public void setSenderAddress(String senderAddress) {
+        this.senderAddress = senderAddress;
     }
 }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/infrastructure/AuthInfrastructureConfiguration.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/infrastructure/AuthInfrastructureConfiguration.java
@@ -1,12 +1,26 @@
 package com.vibe.jobs.auth.infrastructure;
 
+import com.vibe.jobs.auth.config.EmailAuthProperties;
 import com.vibe.jobs.auth.spi.EmailSender;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
 
 @Configuration
 public class AuthInfrastructureConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(prefix = "spring.mail", name = "host")
+    @ConditionalOnBean(JavaMailSender.class)
+    public EmailSender smtpEmailSender(JavaMailSender mailSender,
+                                       EmailAuthProperties emailAuthProperties,
+                                       MailProperties mailProperties) {
+        return new SmtpEmailSender(mailSender, emailAuthProperties, mailProperties);
+    }
 
     @Bean
     @ConditionalOnMissingBean(EmailSender.class)

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/infrastructure/SmtpEmailSender.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/infrastructure/SmtpEmailSender.java
@@ -1,0 +1,76 @@
+package com.vibe.jobs.auth.infrastructure;
+
+import com.vibe.jobs.auth.config.EmailAuthProperties;
+import com.vibe.jobs.auth.domain.EmailAddress;
+import com.vibe.jobs.auth.spi.EmailSender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.mail.MailProperties;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+
+public class SmtpEmailSender implements EmailSender {
+    private static final Logger log = LoggerFactory.getLogger(SmtpEmailSender.class);
+
+    private final JavaMailSender mailSender;
+    private final EmailAuthProperties emailAuthProperties;
+    private final MailProperties mailProperties;
+
+    public SmtpEmailSender(JavaMailSender mailSender,
+                           EmailAuthProperties emailAuthProperties,
+                           MailProperties mailProperties) {
+        this.mailSender = mailSender;
+        this.emailAuthProperties = emailAuthProperties;
+        this.mailProperties = mailProperties;
+    }
+
+    @Override
+    public void sendVerificationCode(EmailAddress email, String code) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(resolveFromAddress());
+        message.setTo(email.value());
+        message.setSubject("Your VibeCoding verification code");
+        message.setText(buildBody(code));
+
+        try {
+            mailSender.send(message);
+            if (log.isDebugEnabled()) {
+                log.debug("Sent verification code email to {}", email.value());
+            }
+        } catch (MailException ex) {
+            log.error("Failed to send verification code email to {}", email.value(), ex);
+            throw ex;
+        }
+    }
+
+    private String resolveFromAddress() {
+        if (StringUtils.hasText(emailAuthProperties.getSenderAddress())) {
+            return emailAuthProperties.getSenderAddress();
+        }
+        if (StringUtils.hasText(mailProperties.getUsername())) {
+            return mailProperties.getUsername();
+        }
+        throw new IllegalStateException("Sender email address is not configured. Set auth.email.senderAddress or spring.mail.username.");
+    }
+
+    private String buildBody(String code) {
+        Duration ttl = emailAuthProperties.getChallengeTtl();
+        long minutes = ttl.toMinutes();
+        if (minutes <= 0) {
+            minutes = Math.max(1, ttl.getSeconds() / 60);
+        }
+
+        String ttlMessage = minutes > 0
+                ? "This code will expire in " + minutes + " minute" + (minutes == 1 ? "" : "s") + "."
+                : "This code will expire soon.";
+
+        return "Hello,\n\n" +
+                "Your verification code is: " + code + "\n" +
+                ttlMessage + "\n\n" +
+                "If you did not request this code, you can safely ignore this email.";
+    }
+}

--- a/vibe-jobs-aggregator/src/main/resources/application.yml
+++ b/vibe-jobs-aggregator/src/main/resources/application.yml
@@ -256,3 +256,4 @@ auth:
     resendCooldown: PT60S
     sessionTtl: P30D
     exposeCodeInResponse: true
+    senderAddress: ${AUTH_EMAIL_SENDER_ADDRESS:}


### PR DESCRIPTION
## Summary
- add a Spring Mail based EmailSender that sends login verification codes via SMTP
- allow configuring the sender address and document the SMTP setup in the README
- fall back to the existing console sender when SMTP properties are absent

## Testing
- mvn test *(fails: dependency downloads are blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97f12b21883289988bae34af8a79f