### PR TITLE
Add configurable category quotas for job ingestion

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/config/IngestionProperties.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/config/IngestionProperties.java
@@ -105,6 +105,7 @@ public class IngestionProperties {
         private boolean enabled = true;
         private boolean runOnStartup = true;
         private Map<String, String> options = new HashMap<>();
+        private List<CategoryQuota> categories = new ArrayList<>();
 
         public String getId() {
             return id;
@@ -146,6 +147,14 @@ public class IngestionProperties {
             this.options = options == null ? new HashMap<>() : options;
         }
 
+        public List<CategoryQuota> getCategories() {
+            return categories;
+        }
+
+        public void setCategories(List<CategoryQuota> categories) {
+            this.categories = categories == null ? new ArrayList<>() : new ArrayList<>(categories);
+        }
+
         public String key() {
             if (id != null && !id.isBlank()) {
                 return id;
@@ -162,6 +171,52 @@ public class IngestionProperties {
                 return "unknown";
             }
             return type.toLowerCase();
+        }
+
+        public static class CategoryQuota {
+            private String name;
+            private int limit;
+            private List<String> tags = new ArrayList<>();
+            private Map<String, List<String>> facets = new HashMap<>();
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public int getLimit() {
+                return Math.max(limit, 0);
+            }
+
+            public void setLimit(int limit) {
+                this.limit = Math.max(limit, 0);
+            }
+
+            public List<String> getTags() {
+                return tags;
+            }
+
+            public void setTags(List<String> tags) {
+                this.tags = tags == null ? new ArrayList<>() : new ArrayList<>(tags);
+            }
+
+            public Map<String, List<String>> getFacets() {
+                return facets;
+            }
+
+            public void setFacets(Map<String, List<String>> facets) {
+                this.facets = new HashMap<>();
+                if (facets == null) {
+                    return;
+                }
+                facets.forEach((key, values) -> {
+                    List<String> normalized = values == null ? new ArrayList<>() : new ArrayList<>(values);
+                    this.facets.put(key, normalized);
+                });
+            }
         }
     }
 

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionScheduler.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionScheduler.java
@@ -6,11 +6,17 @@ import com.vibe.jobs.service.JobDetailService;
 import com.vibe.jobs.service.JobService;
 import com.vibe.jobs.sources.FetchedJob;
 import com.vibe.jobs.sources.SourceClient;
+import com.vibe.jobs.sources.WorkdaySourceClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.LinkedHashMap;
+import java.util.HashSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -62,21 +68,11 @@ public class JobIngestionScheduler {
         String sourceName = sourceClient.sourceName();
         String companyName = configuredSource.company();
         try {
-            int page = 1;
-            while (true) {
-                List<FetchedJob> items = sourceClient.fetchPage(page, pageSize);
-                if (items == null || items.isEmpty()) {
-                    break;
-                }
-                List<FetchedJob> filtered = jobFilter.apply(items);
-                for (FetchedJob fetched : filtered) {
-                    Job persisted = jobService.upsert(fetched.job());
-                    jobDetailService.saveContent(persisted, fetched.content());
-                }
-                if (filtered.isEmpty()) {
-                    log.debug("All jobs filtered out for source {} ({}) on page {}", sourceName, companyName, page);
-                }
-                page++;
+            List<SourceRegistry.CategoryQuota> categories = configuredSource.categories();
+            if (categories == null || categories.isEmpty()) {
+                ingestWithoutCategories(sourceClient, sourceName, companyName, pageSize);
+            } else {
+                ingestWithCategories(configuredSource, pageSize);
             }
             log.info("Ingestion completed for source {} ({})", sourceName, companyName);
         } catch (Exception e) {
@@ -89,5 +85,225 @@ public class JobIngestionScheduler {
                 log.debug("Ingestion failure details", e);
             }
         }
+    }
+
+    private void ingestWithoutCategories(SourceClient sourceClient,
+                                         String sourceName,
+                                         String companyName,
+                                         int pageSize) throws Exception {
+        int page = 1;
+        while (true) {
+            List<FetchedJob> items = sourceClient.fetchPage(page, pageSize);
+            if (items == null || items.isEmpty()) {
+                break;
+            }
+            List<FetchedJob> filtered = jobFilter.apply(items);
+            int persisted = storeJobs(filtered);
+            if (filtered.isEmpty() || persisted == 0) {
+                log.debug("All jobs filtered out for source {} ({}) on page {}", sourceName, companyName, page);
+            }
+            page++;
+        }
+    }
+
+    private void ingestWithCategories(SourceRegistry.ConfiguredSource configuredSource,
+                                      int pageSize) throws Exception {
+        SourceClient client = configuredSource.client();
+        Map<SourceRegistry.CategoryQuota, Integer> remaining = initializeRemaining(configuredSource.categories());
+        if (remaining.isEmpty()) {
+            return;
+        }
+
+        if (client instanceof WorkdaySourceClient workday) {
+            for (SourceRegistry.CategoryQuota category : configuredSource.categories()) {
+                if (!category.hasFacets()) {
+                    continue;
+                }
+                fetchCategoryWithFacets(workday, configuredSource, category, pageSize, remaining);
+                if (allQuotasMet(remaining)) {
+                    return;
+                }
+            }
+        }
+
+        fetchGenericPages(configuredSource, pageSize, remaining);
+    }
+
+    private void fetchGenericPages(SourceRegistry.ConfiguredSource configuredSource,
+                                   int pageSize,
+                                   Map<SourceRegistry.CategoryQuota, Integer> remaining) throws Exception {
+        SourceClient client = configuredSource.client();
+        String sourceName = client.sourceName();
+        String companyName = configuredSource.company();
+        int page = 1;
+        while (!allQuotasMet(remaining)) {
+            List<FetchedJob> items = client.fetchPage(page, pageSize);
+            if (items == null || items.isEmpty()) {
+                break;
+            }
+            List<FetchedJob> filtered = jobFilter.apply(items);
+            int persisted = matchAndStore(filtered, configuredSource, remaining, null, page);
+            if (filtered.isEmpty() || persisted == 0) {
+                log.debug("No category-matched jobs for source {} ({}) on page {}", sourceName, companyName, page);
+            }
+            page++;
+        }
+    }
+
+    private void fetchCategoryWithFacets(WorkdaySourceClient client,
+                                         SourceRegistry.ConfiguredSource configuredSource,
+                                         SourceRegistry.CategoryQuota category,
+                                         int pageSize,
+                                         Map<SourceRegistry.CategoryQuota, Integer> remaining) throws Exception {
+        String sourceName = client.sourceName();
+        String companyName = configuredSource.company();
+        int page = 1;
+        while (remaining.getOrDefault(category, 0) > 0) {
+            List<FetchedJob> items = client.fetchPage(page, pageSize, category.facets());
+            if (items == null || items.isEmpty()) {
+                break;
+            }
+            List<FetchedJob> filtered = jobFilter.apply(items);
+            int persisted = matchAndStore(filtered, configuredSource, remaining, category, page);
+            if (filtered.isEmpty() || persisted == 0) {
+                log.debug("No jobs matched category {} for source {} ({}) on page {} with facets", category.name(), sourceName, companyName, page);
+            }
+            if (allQuotasMet(remaining)) {
+                return;
+            }
+            page++;
+        }
+    }
+
+    private Map<SourceRegistry.CategoryQuota, Integer> initializeRemaining(List<SourceRegistry.CategoryQuota> categories) {
+        Map<SourceRegistry.CategoryQuota, Integer> remaining = new LinkedHashMap<>();
+        if (categories == null) {
+            return remaining;
+        }
+        for (SourceRegistry.CategoryQuota category : categories) {
+            if (category == null) {
+                continue;
+            }
+            int limit = Math.max(category.limit(), 0);
+            if (limit > 0) {
+                remaining.put(category, limit);
+            }
+        }
+        return remaining;
+    }
+
+    private boolean allQuotasMet(Map<SourceRegistry.CategoryQuota, Integer> remaining) {
+        if (remaining.isEmpty()) {
+            return true;
+        }
+        return remaining.values().stream().allMatch(value -> value != null && value <= 0);
+    }
+
+    private int matchAndStore(List<FetchedJob> jobs,
+                              SourceRegistry.ConfiguredSource configuredSource,
+                              Map<SourceRegistry.CategoryQuota, Integer> remaining,
+                              SourceRegistry.CategoryQuota preferredCategory,
+                              int page) {
+        if (jobs == null || jobs.isEmpty()) {
+            return 0;
+        }
+        String sourceName = configuredSource.client().sourceName();
+        String companyName = configuredSource.company();
+        int stored = 0;
+        for (FetchedJob job : jobs) {
+            SourceRegistry.CategoryQuota matched = findMatchingCategory(job, configuredSource.categories(), remaining, preferredCategory);
+            if (matched == null) {
+                continue;
+            }
+            storeJob(job);
+            remaining.computeIfPresent(matched, (key, value) -> value == null ? 0 : Math.max(0, value - 1));
+            stored++;
+            if (allQuotasMet(remaining)) {
+                break;
+            }
+        }
+        if (stored == 0) {
+            log.debug("Jobs fetched for source {} ({}) on page {} did not match remaining category quotas", sourceName, companyName, page);
+        }
+        return stored;
+    }
+
+    private SourceRegistry.CategoryQuota findMatchingCategory(FetchedJob fetched,
+                                                              List<SourceRegistry.CategoryQuota> categories,
+                                                              Map<SourceRegistry.CategoryQuota, Integer> remaining,
+                                                              SourceRegistry.CategoryQuota preferredCategory) {
+        if (categories == null || categories.isEmpty() || fetched == null || fetched.job() == null) {
+            return null;
+        }
+        Set<String> jobTags = normalizeTags(fetched.job().getTags());
+        if (preferredCategory != null) {
+            if (remaining.getOrDefault(preferredCategory, 0) > 0 && matchesCategory(preferredCategory, jobTags)) {
+                return preferredCategory;
+            }
+            return null;
+        }
+        for (SourceRegistry.CategoryQuota category : categories) {
+            if (category == null) {
+                continue;
+            }
+            if (remaining.getOrDefault(category, 0) <= 0) {
+                continue;
+            }
+            if (matchesCategory(category, jobTags)) {
+                return category;
+            }
+        }
+        return null;
+    }
+
+    private boolean matchesCategory(SourceRegistry.CategoryQuota category, Set<String> jobTags) {
+        List<String> requiredTags = category.tags();
+        if (requiredTags == null || requiredTags.isEmpty()) {
+            return true;
+        }
+        for (String tag : requiredTags) {
+            if (jobTags.contains(tag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Set<String> normalizeTags(Set<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> normalized = new HashSet<>();
+        for (String tag : tags) {
+            if (tag == null) {
+                continue;
+            }
+            String trimmed = tag.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            normalized.add(trimmed.toLowerCase(Locale.ROOT));
+        }
+        return normalized;
+    }
+
+    private int storeJobs(List<FetchedJob> jobs) {
+        if (jobs == null || jobs.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        for (FetchedJob fetched : jobs) {
+            storeJob(fetched);
+            count++;
+        }
+        return count;
+    }
+
+    private void storeJob(FetchedJob fetched) {
+        if (fetched == null) {
+            return;
+        }
+        Job persisted = jobService.upsert(fetched.job());
+        jobDetailService.saveContent(persisted, fetched.content());
     }
 }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -21,7 +22,7 @@ public class SourceRegistry {
 
     private final IngestionProperties properties;
     private final SourceClientFactory factory;
-    private final Map<String, ConfiguredSource> cache = new ConcurrentHashMap<>();
+    private final Map<String, SourceClient> clientCache = new ConcurrentHashMap<>();
 
     public SourceRegistry(IngestionProperties properties, SourceClientFactory factory) {
         this.properties = properties;
@@ -61,12 +62,10 @@ public class SourceRegistry {
                     continue;
                 }
                 String cacheKey = source.key() + "::" + trimmedCompany;
+                List<CategoryQuota> categories = resolveCategories(source, trimmedCompany);
                 try {
-                    ConfiguredSource configured = cache.computeIfAbsent(cacheKey, key -> {
-                        SourceClient client = factory.create(type, mergedOptions);
-                        return new ConfiguredSource(source, trimmedCompany, client);
-                    });
-                    resolved.add(configured);
+                    SourceClient client = clientCache.computeIfAbsent(cacheKey, key -> factory.create(type, mergedOptions));
+                    resolved.add(new ConfiguredSource(source, trimmedCompany, client, categories));
                 } catch (Exception ex) {
                     log.warn("Failed to initialize source {} for company {}: {}", source.displayName(), trimmedCompany, ex.getMessage());
                     log.debug("Source initialization error", ex);
@@ -78,7 +77,33 @@ public class SourceRegistry {
 
     public record ConfiguredSource(IngestionProperties.Source definition,
                                    String company,
-                                   SourceClient client) { }
+                                   SourceClient client,
+                                   List<CategoryQuota> categories) {
+        public ConfiguredSource {
+            categories = categories == null ? List.of() : List.copyOf(categories);
+        }
+    }
+
+    public record CategoryQuota(String name,
+                                int limit,
+                                List<String> tags,
+                                Map<String, List<String>> facets) {
+        public CategoryQuota {
+            tags = tags == null ? List.of() : List.copyOf(tags);
+            Map<String, List<String>> normalized = new LinkedHashMap<>();
+            if (facets != null) {
+                facets.forEach((key, values) -> {
+                    List<String> copy = values == null ? List.of() : List.copyOf(values);
+                    normalized.put(key, copy);
+                });
+            }
+            facets = normalized.isEmpty() ? Map.of() : Map.copyOf(normalized);
+        }
+
+        public boolean hasFacets() {
+            return !facets.isEmpty();
+        }
+    }
 
     private Map<String, String> mergeOptions(String type,
                                              IngestionProperties.Source source,
@@ -96,6 +121,65 @@ public class SourceRegistry {
         result.replaceAll((k, v) -> applyPlaceholders(v, companyName));
 
         return result;
+    }
+
+    private List<CategoryQuota> resolveCategories(IngestionProperties.Source source, String companyName) {
+        List<IngestionProperties.Source.CategoryQuota> configured = source.getCategories();
+        if (configured == null || configured.isEmpty()) {
+            return List.of();
+        }
+        List<CategoryQuota> result = new ArrayList<>();
+        for (IngestionProperties.Source.CategoryQuota quota : configured) {
+            if (quota == null) {
+                continue;
+            }
+            int limit = Math.max(quota.getLimit(), 0);
+            if (limit <= 0) {
+                continue;
+            }
+            String name = applyPlaceholders(quota.getName(), companyName);
+            if (name == null || name.isBlank()) {
+                name = "category-" + (result.size() + 1);
+            }
+
+            List<String> tags = quota.getTags() == null ? List.of() : quota.getTags().stream()
+                    .map(tag -> applyPlaceholders(tag, companyName))
+                    .filter(tag -> tag != null && !tag.isBlank())
+                    .map(tag -> tag.trim().toLowerCase(Locale.ROOT))
+                    .distinct()
+                    .toList();
+
+            Map<String, List<String>> facets = resolveFacets(quota.getFacets(), companyName);
+
+            result.add(new CategoryQuota(name, limit, tags, facets));
+        }
+        return result;
+    }
+
+    private Map<String, List<String>> resolveFacets(Map<String, List<String>> facets, String companyName) {
+        if (facets == null || facets.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, List<String>> resolved = new LinkedHashMap<>();
+        facets.forEach((key, values) -> {
+            String resolvedKey = applyPlaceholders(key, companyName);
+            if (resolvedKey == null || resolvedKey.isBlank()) {
+                return;
+            }
+            List<String> normalizedValues = new ArrayList<>();
+            if (values != null) {
+                for (String value : values) {
+                    String resolvedValue = applyPlaceholders(value, companyName);
+                    if (resolvedValue != null && !resolvedValue.isBlank()) {
+                        normalizedValues.add(resolvedValue);
+                    }
+                }
+            }
+            if (!normalizedValues.isEmpty()) {
+                resolved.put(resolvedKey, List.copyOf(normalizedValues));
+            }
+        });
+        return resolved.isEmpty() ? Map.of() : Map.copyOf(resolved);
     }
 
     private Map<String, String> deriveDefaults(String type, String companyName) {

--- a/vibe-jobs-aggregator/src/main/resources/application.yml
+++ b/vibe-jobs-aggregator/src/main/resources/application.yml
@@ -248,6 +248,21 @@ ingestion:
         baseUrl: "https://{{slug}}.wd1.myworkdayjobs.com"
         tenant: "{{slug}}"
         site: "{{slugUpper}}"
+      categories:
+        - name: "{{company}} Engineering"
+          limit: 40
+          tags:
+            - engineering
+            - software
+          facets:
+            jobFamily:
+              - Engineering
+              - "{{companyUpper}} Technology"
+        - name: "{{company}} Financial"
+          limit: 20
+          tags:
+            - finance
+            - financial
 
 
 auth:

--- a/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/ingestion/JobIngestionSchedulerTest.java
+++ b/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/ingestion/JobIngestionSchedulerTest.java
@@ -1,0 +1,153 @@
+package com.vibe.jobs.ingestion;
+
+import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.domain.Job;
+import com.vibe.jobs.service.JobDetailService;
+import com.vibe.jobs.service.JobService;
+import com.vibe.jobs.sources.FetchedJob;
+import com.vibe.jobs.sources.SourceClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class JobIngestionSchedulerTest {
+
+    @Mock
+    private JobService jobService;
+
+    @Mock
+    private JobDetailService jobDetailService;
+
+    private ExecutorService executor;
+
+    @BeforeEach
+    void setUp() {
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.shutdownNow();
+    }
+
+    @Test
+    void shouldRespectCategoryQuotas() {
+        IngestionProperties properties = new IngestionProperties();
+        properties.setPageSize(2);
+
+        JobIngestionFilter filter = new JobIngestionFilter(properties);
+
+        StubSourceClient client = new StubSourceClient();
+        client.addPage(List.of(
+                fetchedJob("eng1", Set.of("Engineering")),
+                fetchedJob("fin1", Set.of("Finance"))
+        ));
+        client.addPage(List.of(
+                fetchedJob("fin2", Set.of("Finance")),
+                fetchedJob("eng2", Set.of("Engineering"))
+        ));
+
+        IngestionProperties.Source definition = new IngestionProperties.Source();
+        definition.setId("stub");
+        definition.setType("greenhouse");
+
+        List<SourceRegistry.CategoryQuota> quotas = List.of(
+                new SourceRegistry.CategoryQuota("engineer", 1, List.of("engineering"), java.util.Map.of()),
+                new SourceRegistry.CategoryQuota("finance", 2, List.of("finance"), java.util.Map.of())
+        );
+        SourceRegistry.ConfiguredSource configuredSource = new SourceRegistry.ConfiguredSource(
+                definition,
+                "Acme",
+                client,
+                quotas
+        );
+
+        SourceRegistry registry = mock(SourceRegistry.class);
+        when(registry.getScheduledSources()).thenReturn(List.of(configuredSource));
+
+        when(jobService.upsert(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        doNothing().when(jobDetailService).saveContent(any(), anyString());
+
+        JobIngestionScheduler scheduler = new JobIngestionScheduler(
+                jobService,
+                properties,
+                registry,
+                filter,
+                jobDetailService,
+                executor
+        );
+
+        scheduler.runIngestion();
+
+        assertThat(client.requestedPages()).containsExactly(1, 2);
+
+        ArgumentCaptor<Job> captor = ArgumentCaptor.forClass(Job.class);
+        verify(jobService, times(3)).upsert(captor.capture());
+        List<String> externalIds = captor.getAllValues().stream().map(Job::getExternalId).toList();
+        assertThat(externalIds).containsExactlyInAnyOrder("eng1", "fin1", "fin2");
+
+        verify(jobDetailService, times(3)).saveContent(any(), anyString());
+    }
+
+    private FetchedJob fetchedJob(String externalId, Set<String> tags) {
+        Job job = Job.builder()
+                .source("stub")
+                .externalId(externalId)
+                .title(externalId)
+                .company("Acme")
+                .postedAt(Instant.now())
+                .tags(new HashSet<>(tags))
+                .build();
+        return FetchedJob.of(job, externalId + "-content");
+    }
+
+    private static class StubSourceClient implements SourceClient {
+        private final List<List<FetchedJob>> pages = new ArrayList<>();
+        private final List<Integer> requestedPages = new ArrayList<>();
+
+        void addPage(List<FetchedJob> jobs) {
+            pages.add(jobs);
+        }
+
+        List<Integer> requestedPages() {
+            return requestedPages;
+        }
+
+        @Override
+        public String sourceName() {
+            return "stub";
+        }
+
+        @Override
+        public List<FetchedJob> fetchPage(int page, int size) {
+            requestedPages.add(page);
+            int index = page - 1;
+            if (index >= 0 && index < pages.size()) {
+                return pages.get(index);
+            }
+            return List.of();
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/ingestion/SourceRegistryTest.java
+++ b/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/ingestion/SourceRegistryTest.java
@@ -1,0 +1,76 @@
+package com.vibe.jobs.ingestion;
+
+import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.sources.FetchedJob;
+import com.vibe.jobs.sources.SourceClient;
+import com.vibe.jobs.sources.SourceClientFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SourceRegistryTest {
+
+    @Test
+    void shouldResolveCategoryConfiguration() {
+        IngestionProperties properties = new IngestionProperties();
+        properties.setCompanies(List.of("Acme Inc"));
+
+        IngestionProperties.Source source = new IngestionProperties.Source();
+        source.setId("workday-acme");
+        source.setType("workday");
+
+        Map<String, String> options = new HashMap<>();
+        options.put("baseUrl", "https://{{slug}}.example.com");
+        options.put("tenant", "{{slug}}");
+        options.put("site", "{{slugUpper}}");
+        source.setOptions(options);
+
+        IngestionProperties.Source.CategoryQuota engineers = new IngestionProperties.Source.CategoryQuota();
+        engineers.setName("{{company}} Engineers");
+        engineers.setLimit(5);
+        engineers.setTags(List.of("Engineering", "Software"));
+        Map<String, List<String>> facets = new HashMap<>();
+        facets.put("jobFamily", List.of("Engineering", "{{companyUpper}} Dev"));
+        engineers.setFacets(facets);
+
+        IngestionProperties.Source.CategoryQuota ignored = new IngestionProperties.Source.CategoryQuota();
+        ignored.setName("Zero quota");
+        ignored.setLimit(0);
+
+        source.setCategories(List.of(engineers, ignored));
+        properties.setSources(List.of(source));
+
+        SourceClientFactory factory = new SourceClientFactory() {
+            @Override
+            public SourceClient create(String type, Map<String, String> opts) {
+                return new SourceClient() {
+                    @Override
+                    public String sourceName() {
+                        return type;
+                    }
+
+                    @Override
+                    public List<FetchedJob> fetchPage(int page, int size) {
+                        return List.of();
+                    }
+                };
+            }
+        };
+
+        SourceRegistry registry = new SourceRegistry(properties, factory);
+        List<SourceRegistry.ConfiguredSource> resolved = registry.getScheduledSources();
+        assertThat(resolved).hasSize(1);
+
+        SourceRegistry.ConfiguredSource configured = resolved.get(0);
+        assertThat(configured.categories()).hasSize(1);
+        SourceRegistry.CategoryQuota quota = configured.categories().get(0);
+        assertThat(quota.name()).isEqualTo("Acme Inc Engineers");
+        assertThat(quota.limit()).isEqualTo(5);
+        assertThat(quota.tags()).containsExactlyInAnyOrder("engineering", "software");
+        assertThat(quota.facets()).containsEntry("jobFamily", List.of("Engineering", "ACME INC Dev"));
+    }
+}


### PR DESCRIPTION
## Summary
- add category quota configuration to ingestion sources and resolve tags/facets during source setup
- update ingestion scheduler to honor per-category quotas with optional Workday facets and add sample configuration
- add unit tests covering category resolution and quota enforcement logic

## Testing
- `mvn test` *(fails: unable to download Spring Boot parent due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f7d9e3548328bca95c86a343ea48