### PR TITLE
Add MySQL profile and deployment configuration updates

### DIFF
--- a/.env
+++ b/.env
@@ -1,13 +1,21 @@
 DOMAIN=elainejobs.com         # 或 jobs.elainejobs.com
 EMAIL=975022570yp@gmail.com         # 用来申请证书
 
+# Spring Boot profile: h2 (default) or mysql
+SPRING_PROFILES_ACTIVE=mysql
 
-SPRING_PROFILES_ACTIVE=prod
-DB_URL=jdbc:h2:file:/data/h2/vibejobs;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE;MODE=PostgreSQL
-DB_USER=sa
-DB_PASSWORD=
-SPRING_JPA_HIBERNATE_DDL_AUTO=update
-SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.h2.Driver
+# MySQL configuration used by docker-compose backend service
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/vibejobs?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=vibejobs
+SPRING_DATASOURCE_PASSWORD=changeme
+SPRING_JPA_HIBERNATE_DDL_AUTO=validate
+SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.MySQLDialect
+
+# Containerised MySQL defaults
+MYSQL_DATABASE=vibejobs
+MYSQL_USER=vibejobs
+MYSQL_PASSWORD=changeme
+MYSQL_ROOT_PASSWORD=rootpass
 
 # 前端
 NEXT_PUBLIC_BACKEND_BASE=/api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,22 @@
 version: "3.9"
 services:
+  mysql:
+    image: mysql:8
+    restart: always
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:vibejobs}
+      MYSQL_USER: ${MYSQL_USER:vibejobs}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:changeme}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:rootpass}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
   caddy:
     image: caddy:2
     restart: always
@@ -18,14 +35,15 @@ services:
     restart: always
     environment:
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
-      - DB_URL=${DB_URL}
-      - DB_USER=${DB_USER}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
+      - SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
+      - SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
       - SPRING_JPA_HIBERNATE_DDL_AUTO=${SPRING_JPA_HIBERNATE_DDL_AUTO}
-      - SPRING_DATASOURCE_DRIVER_CLASS_NAME=${SPRING_DATASOURCE_DRIVER_CLASS_NAME}
+      - SPRING_JPA_DATABASE_PLATFORM=${SPRING_JPA_DATABASE_PLATFORM}
     expose: ["8080"]
-    volumes:
-      - h2data:/data                             # H2 文件持久化卷
+    depends_on:
+      mysql:
+        condition: service_healthy
 
   frontend:
     build:
@@ -42,4 +60,4 @@ services:
 volumes:
   caddy-data:
   caddy-config:
-  h2data:
+  mysql-data:

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -10,10 +10,4 @@ WORKDIR /app
 ENV JAVA_OPTS="-Xms256m -Xmx768m"
 COPY --from=build /app/target/*.jar /app/app.jar
 EXPOSE 8080
-ENTRYPOINT ["/bin/sh","-c","java $JAVA_OPTS -jar /app/app.jar \
-  --spring.datasource.url=${DB_URL:-jdbc:h2:file:/data/h2/vibejobs;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE} \
-  --spring.datasource.username=${DB_USER:-sa} \
-  --spring.datasource.password=${DB_PASSWORD:-} \
-  --spring.datasource.driver-class-name=${SPRING_DATASOURCE_DRIVER_CLASS_NAME:-org.h2.Driver} \
-  --spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:-update} \
-  --server.port=${SERVER_PORT:-8080}"]
+ENTRYPOINT ["/bin/sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/vibe-jobs-aggregator/README.md
+++ b/vibe-jobs-aggregator/README.md
@@ -66,6 +66,24 @@ mvn spring-boot:run
 
 `CareersApiStartupRunner` logs the number of jobs fetched from each source marked `runOnStartup=true`. The `JobIngestionScheduler` reuses the same configuration for recurring updates.
 
+## Database profiles
+
+The service ships with dedicated Spring profiles so you can switch between the embedded H2 database and MySQL without editing configuration files:
+
+- `application-h2.yml` — activates when `SPRING_PROFILES_ACTIVE=h2` (the default). Stores data on the local filesystem and enables the H2 console for quick development feedback.
+- `application-mysql.yml` — activates when `SPRING_PROFILES_ACTIVE=mysql`. It expects a MySQL 8+ instance and defaults to validating the schema on startup.
+
+Both profiles honour the same environment overrides: `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`, `SPRING_JPA_HIBERNATE_DDL_AUTO`, and `SPRING_JPA_DATABASE_PLATFORM`.
+
+```bash
+# Run with MySQL
+SPRING_PROFILES_ACTIVE=mysql \
+SPRING_DATASOURCE_URL=jdbc:mysql://localhost:3306/vibejobs?useSSL=false \
+SPRING_DATASOURCE_USERNAME=vibejobs \
+SPRING_DATASOURCE_PASSWORD=secret \
+mvn spring-boot:run
+```
+
 ### Email verification
 
 To deliver login verification codes, configure an SMTP server using Spring Boot's mail settings and provide a sender address:
@@ -90,6 +108,11 @@ auth:
 ```
 
 If no SMTP configuration is supplied, the application falls back to logging verification codes to the console.
+
+## Docker & deployment
+
+- `docker-compose.yml` now provisions a `mysql:8` container and injects the connection details into the backend service via `SPRING_DATASOURCE_*` environment variables. Update `.env` before running `docker compose up -d` to customise the database name, credentials, or choose the `h2` profile for local experiments.
+- For managed database providers (AWS RDS, Azure Database for MySQL, etc.) set `SPRING_PROFILES_ACTIVE=mysql` and supply the managed endpoint credentials (`SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`) through your host environment or secrets manager. Ensure the security group / firewall allows inbound traffic from the application subnet on port 3306 while keeping the instance closed to the public internet.
 
 ## Notes
 - Greenhouse does not return `postedAt`; we stamp the current time. Extend `GreenhouseSourceClient` if you need more metadata.

--- a/vibe-jobs-aggregator/pom.xml
+++ b/vibe-jobs-aggregator/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>spring-boot-starter-mail</artifactId>
     </dependency>
     <dependency><groupId>com.h2database</groupId><artifactId>h2</artifactId><scope>runtime</scope></dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency><groupId>org.jsoup</groupId><artifactId>jsoup</artifactId><version>1.17.2</version></dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>
     <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></dependency>

--- a/vibe-jobs-aggregator/src/main/resources/application-h2.yml
+++ b/vibe-jobs-aggregator/src/main/resources/application-h2.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: h2
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:${DB_URL:jdbc:h2:file:./data/jobsdb;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE}}
+    username: ${SPRING_DATASOURCE_USERNAME:${DB_USER:sa}}
+    password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD:}}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.h2.Driver}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true

--- a/vibe-jobs-aggregator/src/main/resources/application-mysql.yml
+++ b/vibe-jobs-aggregator/src/main/resources/application-mysql.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    activate:
+      on-profile: mysql
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:${DB_URL:jdbc:mysql://localhost:3306/vibejobs?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC}}
+    username: ${SPRING_DATASOURCE_USERNAME:${DB_USER:vibejobs}}
+    password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD:changeme}}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:com.mysql.cj.jdbc.Driver}
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:validate}
+    database-platform: ${SPRING_JPA_DATABASE_PLATFORM:org.hibernate.dialect.MySQLDialect}
+    properties:
+      hibernate:
+        format_sql: true

--- a/vibe-jobs-aggregator/src/main/resources/application.yml
+++ b/vibe-jobs-aggregator/src/main/resources/application.yml
@@ -1,19 +1,6 @@
-
 spring:
-  datasource:
-    url: ${SPRING_DATASOURCE_URL:${DB_URL:jdbc:h2:file:./data/jobsdb;DB_CLOSE_DELAY=-1;AUTO_SERVER=TRUE}}
-    username: ${SPRING_DATASOURCE_USERNAME:${DB_USER:sa}}
-    password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD:}}
-    driver-class-name: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.h2.Driver}
-  jpa:
-    hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    properties:
-      hibernate:
-        format_sql: true
-  h2:
-    console:
-      enabled: true
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:h2}
 server:
   port: ${SERVER_PORT:8080}
   servlet:


### PR DESCRIPTION
## Summary
- add the MySQL JDBC driver and split database settings into H2/MySQL profile files
- trim the base application.yml to shared settings and document the profile workflow
- update Docker assets and .env to provision a MySQL service and rely on Spring profile env vars

## Testing
- mvn -q -DskipTests package *(fails: repository access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da06e53d2883288c0463404b5b7629