### PR TITLE
feat: add Flyway-managed indexes for job filtering

### DIFF
--- a/vibe-jobs-aggregator/README.md
+++ b/vibe-jobs-aggregator/README.md
@@ -96,3 +96,22 @@ If no SMTP configuration is supplied, the application falls back to logging veri
 - Lever timestamps are provided in epoch milliseconds and are normalised to `Instant`.
 - Workday endpoints vary by tenant/site; ensure `baseUrl`, `tenant`, and `site` values match the organisation you are integrating.
 - Job descriptions are stored in the `job_details` table and exposed via `GET /jobs/{id}/detail` so the frontend can lazy-load content.
+
+## Database indexes & query tuning
+
+- Flyway manages production indexes under `src/main/resources/db/migration`. New composite indexes cover the most common filters:
+  - `idx_jobs_posted_at_id_desc` to fetch the newest jobs first while avoiding filesorts.
+  - Functional indexes on `LOWER(company)` and `LOWER(location)` combined with `posted_at` to accelerate case-insensitive filters plus recency sorting. MySQL requires version **8.0.13+** for expression indexes.
+  - `idx_jobs_level` for exact level matches and two supporting indexes on `job_tags` (`tag` and `(job_id, tag)`) to speed up tag joins.
+- For future text search needs, prefer MySQL 8.0 `FULLTEXT` indexes on `title` / `description` or an external search service (e.g. OpenSearch). MySQL `FULLTEXT` indexes only work on InnoDB tables starting in 5.6; configure them via a dedicated Flyway migration so lower environments stay in sync.
+- Verify that queries benefit from the indexes with `EXPLAIN`, e.g.:
+
+  ```sql
+  EXPLAIN SELECT id, title FROM jobs
+  WHERE LOWER(company) = LOWER('Acme')
+  ORDER BY posted_at DESC, id DESC
+  LIMIT 20;
+  ```
+
+  Inspect the `key`/`key_len` columns to confirm index usage. Combine with `ANALYZE TABLE jobs;` after large data imports so the optimizer statistics stay fresh.
+- When deploying to new environments, baseline the existing schema (`spring.flyway.baseline-on-migrate=true`) before applying migrations to avoid checksum conflicts. Hibernate's `ddl-auto` should be set to `validate` or `none` in production; schema changes—including new indexes—must be introduced through Flyway scripts.

--- a/vibe-jobs-aggregator/pom.xml
+++ b/vibe-jobs-aggregator/pom.xml
@@ -32,6 +32,14 @@
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-validation</artifactId></dependency>
     <dependency><groupId>com.fasterxml.jackson.core</groupId><artifactId>jackson-databind</artifactId></dependency>
     <dependency><groupId>org.springdoc</groupId><artifactId>springdoc-openapi-starter-webmvc-ui</artifactId><version>2.5.0</version></dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.flywaydb</groupId>
+      <artifactId>flyway-mysql</artifactId>
+    </dependency>
     <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
   </dependencies>
   <build>

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V3__add_mysql_indexes.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V3__add_mysql_indexes.sql
@@ -1,0 +1,9 @@
+-- Add composite and supporting indexes for common job queries
+CREATE INDEX idx_jobs_posted_at_id_desc ON jobs (posted_at DESC, id DESC);
+CREATE INDEX idx_jobs_company_posted_at ON jobs ((LOWER(company)), posted_at);
+CREATE INDEX idx_jobs_location_posted_at ON jobs ((LOWER(location)), posted_at);
+CREATE INDEX idx_jobs_level ON jobs (level);
+
+-- Improve tag lookups and joins
+CREATE INDEX idx_job_tags_tag ON job_tags (tag);
+CREATE INDEX idx_job_tags_job_tag ON job_tags (job_id, tag);


### PR DESCRIPTION
## Summary
- add a Flyway migration that builds composite indexes for common job and tag filters
- include Flyway dependencies so the aggregator service can run migrations against MySQL
- document index management, future full-text options, and query-plan verification steps in the README

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 while downloading the Spring Boot parent)*

------
https://chatgpt.com/codex/tasks/task_e_68da06e788f88328b78aec0704b7c30e