### PR TITLE
Resolve project directory before sourcing production env file

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,11 @@
+# Copy this file to .env.production on the server and fill in the secrets before
+# running ./deploy.sh. The backend reads these variables to connect to the managed
+# Aurora/RDS instance and Flyway will bootstrap the schema automatically.
+SPRING_PROFILES_ACTIVE=mysql,prod
+SPRING_DATASOURCE_URL=jdbc:mysql://database-vibejobs.clgia4qkyyuz.ap-southeast-1.rds.amazonaws.com:3306/vibejobs?useSSL=true&requireSSL=true&allowPublicKeyRetrieval=true&serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=vibejobs
+SPRING_DATASOURCE_PASSWORD=vibejobs
+SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
+SPRING_JPA_DATABASE_PLATFORM=org.hibernate.dialect.MySQLDialect
+SPRING_JPA_HIBERNATE_DDL_AUTO=validate
+SPRING_FLYWAY_SCHEMAS=vibejobs

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cd ~/app
+
+# Resolve the repo directory so sourcing works even if we invoke the script
+# from another working directory (e.g. via cron or a CI pipeline).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
+
+# Load production overrides (database credentials, etc.) if present. This lets us
+# keep secrets outside of version control while still exporting them for the
+# compose deployment below.
+if [[ -f "$PROJECT_DIR/.env.production" ]]; then
+  echo ">> loading environment overrides from $PROJECT_DIR/.env.production"
+  # shellcheck disable=SC1091
+  set -a
+  source "$PROJECT_DIR/.env.production"
+  set +a
+fi
+
+cd "$PROJECT_DIR"
 BRANCH="${1:-master}"
 
 export SPRING_PROFILES_ACTIVE="${SPRING_PROFILES_ACTIVE:-mysql,prod}"

--- a/vibe-jobs-aggregator/README.md
+++ b/vibe-jobs-aggregator/README.md
@@ -112,6 +112,7 @@ If no SMTP configuration is supplied, the application falls back to logging veri
 
 - `docker-compose.yml` now provisions a `mysql:8` container and injects the connection details into the backend service via `SPRING_DATASOURCE_*` environment variables. Update `.env` before running `docker compose up -d` to customise the database name, credentials, or choose the `h2` profile for local experiments.
 - For managed database providers (AWS RDS, Azure Database for MySQL, etc.) set `SPRING_PROFILES_ACTIVE=mysql` and supply the managed endpoint credentials (`SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD`) through your host environment or secrets manager. Ensure the security group / firewall allows inbound traffic from the application subnet on port 3306 while keeping the instance closed to the public internet.
+- A production checklist for Aurora/RDS lives in `docs/production-rds-checklist.md`. Copy `.env.production.example` to `.env.production`, override the secrets, and `deploy.sh` will automatically export the variables before rebuilding the containers.
 
 ## Notes
 - Greenhouse does not return `postedAt`; we stamp the current time. Extend `GreenhouseSourceClient` if you need more metadata.

--- a/vibe-jobs-aggregator/docs/production-rds-checklist.md
+++ b/vibe-jobs-aggregator/docs/production-rds-checklist.md
@@ -1,0 +1,48 @@
+# Aurora/RDS Production Database Checklist
+
+Use this checklist when deploying the backend to AWS ECS with an Aurora MySQL or
+RDS MySQL cluster. The goal is to ensure the service can authenticate against
+the managed database and that Flyway bootstraps the schema before traffic
+arrives.
+
+## 1. Networking and access
+- [ ] Place the ECS service in the same VPC/subnets as the database or ensure
+      peering is configured.
+- [ ] Add inbound rules to the database security group allowing port `3306`
+      from the ECS task security group only (keep the instance private to the
+      internet).
+- [ ] Confirm the database endpoint resolves from the ECS tasks (e.g. via
+      `nslookup database-vibejobs.clgia4qkyyuz.ap-southeast-1.rds.amazonaws.com`).
+
+## 2. Prepare application environment variables
+Create a `.env.production` file beside `deploy.sh` or configure the equivalent
+variables in the ECS task definition/Secrets Manager:
+
+| Variable | Example value | Notes |
+| --- | --- | --- |
+| `SPRING_PROFILES_ACTIVE` | `mysql,prod` | Enables the MySQL profile and production overrides. |
+| `SPRING_DATASOURCE_URL` | `jdbc:mysql://database-vibejobs.clgia4qkyyuz.ap-southeast-1.rds.amazonaws.com:3306/vibejobs?useSSL=true&requireSSL=true&allowPublicKeyRetrieval=true&serverTimezone=UTC` | Replace host/port if your cluster differs. |
+| `SPRING_DATASOURCE_USERNAME` | `vibejobs` | Aurora user with DDL/DML permissions. |
+| `SPRING_DATASOURCE_PASSWORD` | `********` | Store in Secrets Manager or SSM Parameter Store. |
+| `SPRING_DATASOURCE_DRIVER_CLASS_NAME` | `com.mysql.cj.jdbc.Driver` | Ensures the correct JDBC driver is used. |
+| `SPRING_JPA_DATABASE_PLATFORM` | `org.hibernate.dialect.MySQLDialect` | Keeps Hibernate aligned with MySQL syntax. |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | `validate` | Prevents Hibernate from altering schema; Flyway owns migrations. |
+| `SPRING_FLYWAY_SCHEMAS` | `vibejobs` | Matches the database name created in RDS. |
+
+If you copy `.env.production.example`, make sure to update the password and any
+database-specific overrides before deploying.
+
+## 3. Run Flyway migrations once
+- [ ] Ensure the `vibejobs` schema exists: `CREATE DATABASE vibejobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`
+- [ ] Trigger a backend deployment (`./deploy.sh` or an ECS force deployment).
+- [ ] Watch the backend logs; Flyway should emit `Successfully applied 2 migrations`.
+- [ ] Verify tables with `mysql -h <endpoint> -u vibejobs -p -e 'SHOW TABLES IN vibejobs;'`.
+
+## 4. Post-deployment verification
+- [ ] Hit `https://<your-domain>/api/actuator/health` and confirm status `UP`.
+- [ ] Run a manual ingestion (`POST /api/jobs/refresh`) or wait for the
+      scheduler and confirm new rows appear in `jobs`/`job_details`.
+- [ ] Enable CloudWatch alarms on ECS task failures and RDS CPU/storage metrics.
+
+Following this checklist keeps production aligned with the validated local
+setup while letting Flyway manage schema changes safely.


### PR DESCRIPTION
## Summary
- detect the deploy script's directory so it can source .env.production even when invoked from elsewhere
- default the working directory to the script location instead of hard-coding ~/app

## Testing
- not run (infrastructure script update)


------
https://chatgpt.com/codex/tasks/task_e_68da932cc51c8328a70591eca5127007