### PR TITLE
Fix MySQL default env interpolation in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
     image: mysql:8
     restart: always
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE:vibejobs}
-      MYSQL_USER: ${MYSQL_USER:vibejobs}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:changeme}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:rootpass}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-vibejobs}
+      MYSQL_USER: ${MYSQL_USER:-vibejobs}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-vibejobs}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-rootpass}
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## Summary
- update MySQL environment variable defaults to use shell-compatible `${VAR:-default}` syntax so Docker Compose can parse the file
- align the default MySQL user password with the backend's expected value to avoid authentication failures

## Testing
- `docker compose config` *(fails: docker executable is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa0e8999c8328b1bc0a70db5cc518