### PR TITLE
Ensure production deployments use RDS configuration

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,6 +1,8 @@
 # Update this file with the production secrets before running `./deploy.sh`.
-# The backend reads these variables to connect to the managed Aurora/RDS
-# instance and Flyway will bootstrap the schema automatically.
+# Values defined here override the defaults in `.env`, ensuring the backend
+# connects to the managed Aurora/RDS instance instead of the local docker MySQL
+# container when deploying to production. Flyway will bootstrap the schema
+# automatically.
 SPRING_PROFILES_ACTIVE=mysql,prod
 SPRING_DATASOURCE_URL="jdbc:mysql://database-vibejobs.clgia4qkyyuz.ap-southeast-1.rds.amazonaws.com:3306/vibejobs?useSSL=true&requireSSL=true&allowPublicKeyRetrieval=true&serverTimezone=UTC"
 SPRING_DATASOURCE_USERNAME=vibejobs

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,14 +6,64 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
 
-# Load production overrides (database credentials, etc.) if present. This lets us
-# keep secrets outside of version control while still exporting them for the
-# compose deployment below.
+TMP_ENV_FILE=""
+
+cleanup() {
+  if [[ -n "${TMP_ENV_FILE:-}" && -f "${TMP_ENV_FILE}" ]]; then
+    rm -f "${TMP_ENV_FILE}"
+  fi
+}
+
+trap cleanup EXIT
+
+# Compose reads variables from a single env file. We merge `.env` (base defaults)
+# with `.env.production` (overrides for managed services) so production deploys
+# don't accidentally fall back to the local dockerised MySQL host.
+ENV_FILES=()
+if [[ -f "$PROJECT_DIR/.env" ]]; then
+  ENV_FILES+=("$PROJECT_DIR/.env")
+fi
+
 if [[ -f "$PROJECT_DIR/.env.production" ]]; then
   echo ">> loading environment overrides from $PROJECT_DIR/.env.production"
-  # shellcheck disable=SC1091
+  ENV_FILES+=("$PROJECT_DIR/.env.production")
+fi
+
+COMPOSE_ENV_FILE=""
+if (( ${#ENV_FILES[@]} > 0 )); then
+  if (( ${#ENV_FILES[@]} > 1 )); then
+    TMP_ENV_FILE="$(mktemp)"
+
+    declare -A override_keys=()
+    while IFS= read -r key; do
+      [[ -z "$key" ]] && continue
+      override_keys["$key"]=1
+    done < <(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$PROJECT_DIR/.env.production" | cut -d= -f1)
+
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)= ]]; then
+        key="${BASH_REMATCH[1]}"
+        if [[ -n "${override_keys[$key]:-}" ]]; then
+          continue
+        fi
+      fi
+      printf '%s\n' "$line" >> "$TMP_ENV_FILE"
+    done < "$PROJECT_DIR/.env"
+
+    printf '\n' >> "$TMP_ENV_FILE"
+    cat "$PROJECT_DIR/.env.production" >> "$TMP_ENV_FILE"
+    printf '\n' >> "$TMP_ENV_FILE"
+
+    COMPOSE_ENV_FILE="$TMP_ENV_FILE"
+  else
+    COMPOSE_ENV_FILE="${ENV_FILES[0]}"
+  fi
+
   set -a
-  source "$PROJECT_DIR/.env.production"
+  for file in "${ENV_FILES[@]}"; do
+    # shellcheck disable=SC1090
+    source "$file"
+  done
   set +a
 fi
 
@@ -31,12 +81,18 @@ git fetch --all --prune
 git checkout "$BRANCH"
 git pull
 
+COMPOSE_CMD=(docker compose)
+if [[ -n "$COMPOSE_ENV_FILE" ]]; then
+  COMPOSE_CMD+=(--env-file "$COMPOSE_ENV_FILE")
+  echo ">> using docker compose env file $COMPOSE_ENV_FILE"
+fi
+
 echo ">> build images"
-docker compose build --pull backend frontend
+"${COMPOSE_CMD[@]}" build --pull backend frontend
 
 echo ">> deploy"
-docker compose up -d --remove-orphans
+"${COMPOSE_CMD[@]}" up -d --remove-orphans
 
 echo ">> status"
-docker compose ps
+"${COMPOSE_CMD[@]}" ps
 

--- a/vibe-jobs-aggregator/docs/production-rds-checklist.md
+++ b/vibe-jobs-aggregator/docs/production-rds-checklist.md
@@ -30,7 +30,9 @@ variables in the ECS task definition/Secrets Manager:
 | `SPRING_FLYWAY_SCHEMAS` | `vibejobs` | Matches the database name created in RDS. |
 
 Ensure `.env.production` contains the latest password and any
-database-specific overrides before deploying.
+database-specific overrides before deploying. The `deploy.sh` helper merges
+`.env` with `.env.production`, allowing the production secrets to override the
+local docker settings so the backend connects to the managed RDS endpoint.
 
 ## 3. Run Flyway migrations once
 - [ ] Ensure the `vibejobs` schema exists: `CREATE DATABASE vibejobs CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;`


### PR DESCRIPTION
## Summary
- merge the base `.env` defaults with `.env.production` so deploy.sh passes the RDS connection details to docker compose
- document the override behaviour for production secrets in `.env.production` and the RDS deployment checklist

## Testing
- not run (not applicable for deployment script changes)


------
https://chatgpt.com/codex/tasks/task_e_68dabb359a608328b5a11096bf023188