### PR TITLE
Fix mobile job list scroll detection

### DIFF
--- a/vibe-jobs-view/app/(site)/page.tsx
+++ b/vibe-jobs-view/app/(site)/page.tsx
@@ -329,6 +329,9 @@ export default function Page() {
     const loadMoreElement = loadMoreRef.current;
     if (!loadMoreElement) return;
 
+    const listElement = listRef.current;
+    const isScrollable = !!listElement && listElement.scrollHeight > listElement.clientHeight + 1;
+
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
@@ -337,18 +340,18 @@ export default function Page() {
         }
       },
       {
-        root: listRef.current,
+        root: isScrollable ? listElement : null,
         rootMargin: '20px', // 提前20px触发
-        threshold: 0.1
+        threshold: 0.1,
       }
     );
 
     observer.observe(loadMoreElement);
 
     return () => {
-      observer.unobserve(loadMoreElement);
+      observer.disconnect();
     };
-  }, [hasMore, loading, nextCursor]);
+  }, [hasMore, loading, nextCursor, jobs.length]);
 
   // 过滤计数
   const activeFilterCount = useMemo(


### PR DESCRIPTION
## Summary
- update the jobs list intersection observer to fall back to the viewport on mobile where the list is not scrollable
- clean up the observer properly to avoid leaking watchers

## Testing
- pnpm lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db301024d88328bd18d905bc7f0f6c