### PR TITLE
Refactor ingestion sources to load from database

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceCommandService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceCommandService.java
@@ -1,0 +1,25 @@
+package com.vibe.jobs.datasource.application;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSourceRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+
+@Service
+public class DataSourceCommandService {
+
+    private final JobDataSourceRepository repository;
+
+    public DataSourceCommandService(JobDataSourceRepository repository) {
+        this.repository = repository;
+    }
+
+    public JobDataSource save(JobDataSource source) {
+        return repository.save(source);
+    }
+
+    public void saveAll(Collection<JobDataSource> sources) {
+        repository.saveAll(sources);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceQueryService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceQueryService.java
@@ -1,0 +1,43 @@
+package com.vibe.jobs.datasource.application;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSourceRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+@Service
+public class DataSourceQueryService {
+
+    private final JobDataSourceRepository repository;
+
+    public DataSourceQueryService(JobDataSourceRepository repository) {
+        this.repository = repository;
+    }
+
+    public List<JobDataSource> fetchAllEnabled() {
+        return repository.findAllEnabled();
+    }
+
+    public List<JobDataSource> fetchStartupSources() {
+        return repository.findAllEnabled().stream()
+                .filter(JobDataSource::isRunOnStartup)
+                .collect(Collectors.toList());
+    }
+
+    public Set<String> getNormalizedCompanyNames() {
+        Set<String> names = new TreeSet<>();
+        for (JobDataSource source : repository.findAllEnabled()) {
+            source.getCompanies().stream()
+                    .filter(JobDataSource.DataSourceCompany::enabled)
+                    .map(company -> company.displayName().isBlank() ? company.reference() : company.displayName())
+                    .map(value -> value == null ? "" : value.trim().toLowerCase())
+                    .filter(value -> !value.isBlank())
+                    .forEach(names::add);
+        }
+        return names;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/migration/LegacyIngestionConfigurationImporter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/migration/LegacyIngestionConfigurationImporter.java
@@ -1,0 +1,150 @@
+package com.vibe.jobs.datasource.application.migration;
+
+import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.datasource.application.DataSourceCommandService;
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSource.CategoryQuotaDefinition;
+import com.vibe.jobs.datasource.domain.JobDataSource.DataSourceCompany;
+import com.vibe.jobs.datasource.domain.JobDataSource.Flow;
+import com.vibe.jobs.datasource.domain.JobDataSourceRepository;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(prefix = "ingestion.migration", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class LegacyIngestionConfigurationImporter {
+
+    private static final Logger log = LoggerFactory.getLogger(LegacyIngestionConfigurationImporter.class);
+
+    private final IngestionProperties legacyProperties;
+    private final DataSourceCommandService commandService;
+    private final JobDataSourceRepository repository;
+
+    public LegacyIngestionConfigurationImporter(IngestionProperties legacyProperties,
+                                                DataSourceCommandService commandService,
+                                                JobDataSourceRepository repository) {
+        this.legacyProperties = legacyProperties;
+        this.commandService = commandService;
+        this.repository = repository;
+    }
+
+    @PostConstruct
+    public void migrateIfNecessary() {
+        if (repository.existsAny()) {
+            log.info("Job data sources already initialized; skipping legacy ingestion migration");
+            return;
+        }
+        if (legacyProperties.getSources() == null || legacyProperties.getSources().isEmpty()) {
+            log.info("No legacy ingestion sources configured; skipping migration");
+            return;
+        }
+
+        log.info("Migrating legacy ingestion configuration to database");
+        List<JobDataSource> sources = new ArrayList<>();
+        for (IngestionProperties.Source source : legacyProperties.getSources()) {
+            if (source == null || source.getType() == null || source.getType().isBlank()) {
+                continue;
+            }
+            JobDataSource dataSource = buildDataSource(source);
+            if (dataSource == null) {
+                continue;
+            }
+            sources.add(dataSource);
+        }
+        if (sources.isEmpty()) {
+            log.info("No valid legacy data sources found; skipping migration");
+            return;
+        }
+        commandService.saveAll(sources);
+        log.info("Migrated {} legacy ingestion sources to the database", sources.size());
+    }
+
+    private JobDataSource buildDataSource(IngestionProperties.Source source) {
+        Map<String, String> baseOptions = new LinkedHashMap<>(source.getOptions());
+        List<CategoryQuotaDefinition> categories = new ArrayList<>();
+        if (source.getCategories() != null) {
+            for (IngestionProperties.Source.CategoryQuota quota : source.getCategories()) {
+                if (quota == null || quota.getLimit() <= 0) {
+                    continue;
+                }
+                categories.add(new CategoryQuotaDefinition(
+                        quota.getName(),
+                        quota.getLimit(),
+                        quota.getTags(),
+                        quota.getFacets()
+                ));
+            }
+        }
+
+        List<DataSourceCompany> companies = resolveCompaniesForSource(source);
+        return new JobDataSource(
+                null,
+                normalizeCode(source),
+                source.getType(),
+                source.isEnabled(),
+                source.isRunOnStartup(),
+                source.isRequireOverride(),
+                source.getFlow() == IngestionProperties.Source.Flow.LIMITED ? Flow.LIMITED : Flow.UNLIMITED,
+                baseOptions,
+                categories,
+                companies
+        ).normalized();
+    }
+
+    private List<DataSourceCompany> resolveCompaniesForSource(IngestionProperties.Source source) {
+        List<DataSourceCompany> companies = new ArrayList<>();
+        List<String> legacyCompanies = legacyProperties.getCompanies();
+        if (legacyCompanies == null || legacyCompanies.isEmpty()) {
+            return companies;
+        }
+        for (String companyName : legacyCompanies) {
+            if (companyName == null || companyName.isBlank()) {
+                continue;
+            }
+            String trimmed = companyName.trim();
+            IngestionProperties.SourceOverride override = legacyProperties.getSourceOverride(trimmed, source.getType());
+            if (override == null && source.isRequireOverride()) {
+                continue;
+            }
+            boolean enabled = override == null || override.isEnabled();
+            Map<String, String> overrideOptions = override == null ? Map.of() : override.optionsCopy();
+            Map<String, String> placeholders = legacyProperties.getPlaceholderOverrides(trimmed);
+            DataSourceCompany company = new DataSourceCompany(
+                    null,
+                    trimmed,
+                    trimmed,
+                    slugify(trimmed),
+                    enabled,
+                    placeholders,
+                    overrideOptions
+            );
+            companies.add(company.normalized());
+        }
+        return companies;
+    }
+
+    private String normalizeCode(IngestionProperties.Source source) {
+        if (source.getId() != null && !source.getId().isBlank()) {
+            return source.getId().trim().toLowerCase(Locale.ROOT);
+        }
+        return source.getType().trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String slugify(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-|-$", "");
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
@@ -1,0 +1,20 @@
+package com.vibe.jobs.datasource.domain;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface JobDataSourceRepository {
+
+    List<JobDataSource> findAllEnabled();
+
+    List<JobDataSource> findAll();
+
+    Optional<JobDataSource> findById(Long id);
+
+    JobDataSource save(JobDataSource dataSource);
+
+    void saveAll(Collection<JobDataSource> sources);
+
+    boolean existsAny();
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/PlaceholderContext.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/PlaceholderContext.java
@@ -1,0 +1,118 @@
+package com.vibe.jobs.datasource.domain;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public record PlaceholderContext(String company,
+                                 String companyLower,
+                                 String companyUpper,
+                                 String slug,
+                                 String slugUpper,
+                                 Map<String, String> custom) {
+
+    public PlaceholderContext {
+        company = sanitize(company);
+        companyLower = sanitize(companyLower);
+        companyUpper = sanitize(companyUpper);
+        slug = sanitize(slug);
+        slugUpper = sanitize(slugUpper);
+        custom = custom == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(custom));
+    }
+
+    private static String sanitize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public PlaceholderContext withCustom(String key, String value) {
+        if (key == null || key.isBlank()) {
+            return this;
+        }
+        Map<String, String> updated = new LinkedHashMap<>(custom);
+        if (value == null) {
+            updated.remove(key);
+        } else {
+            updated.put(key.trim(), value);
+        }
+        return new PlaceholderContext(company, companyLower, companyUpper, slug, slugUpper, updated);
+    }
+
+    public String apply(String value) {
+        if (value == null) {
+            return null;
+        }
+        String replaced = value
+                .replace("{{company}}", company)
+                .replace("{{companyLower}}", companyLower)
+                .replace("{{companyUpper}}", companyUpper)
+                .replace("{{slug}}", slug)
+                .replace("{{slugUpper}}", slugUpper);
+        for (Map.Entry<String, String> entry : custom.entrySet()) {
+            replaced = replaced.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return replaced;
+    }
+
+    public static PlaceholderContext forCompany(JobDataSource.DataSourceCompany company) {
+        String reference = company == null ? "" : company.reference();
+        String displayName = company == null ? "" : company.displayName();
+        String slug = company == null ? "" : company.slug();
+
+        String normalizedCompany = displayName.isBlank() ? reference : displayName;
+        if (normalizedCompany.isBlank()) {
+            normalizedCompany = reference;
+        }
+        normalizedCompany = normalizedCompany == null ? "" : normalizedCompany.trim();
+        if (slug.isBlank()) {
+            slug = slugify(normalizedCompany.isBlank() ? reference : normalizedCompany);
+        }
+        String lower = normalizedCompany.toLowerCase(Locale.ROOT);
+        String upper = normalizedCompany.toUpperCase(Locale.ROOT);
+        String slugUpper = slug.toUpperCase(Locale.ROOT);
+
+        Map<String, String> overrides = new LinkedHashMap<>(company == null ? Map.of() : company.placeholderOverrides());
+        String overrideCompany = overrides.remove("company");
+        if (overrideCompany != null && !overrideCompany.isBlank()) {
+            normalizedCompany = overrideCompany.trim();
+            lower = normalizedCompany.toLowerCase(Locale.ROOT);
+            upper = normalizedCompany.toUpperCase(Locale.ROOT);
+        }
+        String overrideSlug = overrides.remove("slug");
+        if (overrideSlug != null && !overrideSlug.isBlank()) {
+            slug = overrideSlug.trim();
+        }
+        String overrideSlugUpper = overrides.remove("slugUpper");
+        if (overrideSlugUpper != null && !overrideSlugUpper.isBlank()) {
+            slugUpper = overrideSlugUpper.trim();
+        } else {
+            slugUpper = slug.toUpperCase(Locale.ROOT);
+        }
+        String overrideLower = overrides.remove("companyLower");
+        if (overrideLower != null && !overrideLower.isBlank()) {
+            lower = overrideLower.trim();
+        }
+        String overrideUpper = overrides.remove("companyUpper");
+        if (overrideUpper != null && !overrideUpper.isBlank()) {
+            upper = overrideUpper.trim();
+        }
+
+        return new PlaceholderContext(
+                normalizedCompany,
+                lower,
+                upper,
+                slug,
+                slugUpper,
+                overrides
+        );
+    }
+
+    private static String slugify(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        return value.toLowerCase(Locale.ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("^-|-$", "");
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/SourceOptionDefaults.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/SourceOptionDefaults.java
@@ -1,0 +1,36 @@
+package com.vibe.jobs.datasource.domain;
+
+import java.util.Locale;
+import java.util.Map;
+
+public final class SourceOptionDefaults {
+
+    private SourceOptionDefaults() {
+    }
+
+    public static Map<String, String> derive(String type, PlaceholderContext context) {
+        if (type == null || type.isBlank()) {
+            return Map.of();
+        }
+        String normalizedType = type.toLowerCase(Locale.ROOT);
+        String slug = context.slug();
+        String company = context.company();
+        return switch (normalizedType) {
+            case "greenhouse" -> Map.of("slug", slug);
+            case "lever" -> Map.of("company", slug);
+            case "workday" -> Map.of(
+                    "baseUrl", slug.isBlank() ? "" : "https://" + slug + ".wd1.myworkdayjobs.com",
+                    "tenant", slug,
+                    "site", context.slugUpper()
+            );
+            case "ashby" -> Map.of(
+                    "company", company,
+                    "baseUrl", slug.isBlank() ? "" : "https://jobs.ashbyhq.com/" + slug
+            );
+            case "smartrecruiters" -> Map.of("company", company);
+            case "recruitee" -> Map.of("company", slug);
+            case "workable" -> Map.of("company", slug);
+            default -> Map.of();
+        };
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceCategoryEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceCategoryEntity.java
@@ -1,0 +1,93 @@
+package com.vibe.jobs.datasource.infrastructure.jpa;
+
+import com.vibe.jobs.datasource.infrastructure.jpa.converter.JsonStringListConverter;
+import com.vibe.jobs.datasource.infrastructure.jpa.converter.JsonStringListMapConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "job_data_source_category")
+public class JobDataSourceCategoryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "data_source_id", nullable = false)
+    private JobDataSourceEntity dataSource;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "quota_limit", nullable = false)
+    private int limit;
+
+    @Column(columnDefinition = "text")
+    @Convert(converter = JsonStringListConverter.class)
+    private List<String> tags = List.of();
+
+    @Column(columnDefinition = "text")
+    @Convert(converter = JsonStringListMapConverter.class)
+    private Map<String, List<String>> facets = new LinkedHashMap<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public JobDataSourceEntity getDataSource() {
+        return dataSource;
+    }
+
+    public void setDataSource(JobDataSourceEntity dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, List<String>> getFacets() {
+        return facets;
+    }
+
+    public void setFacets(Map<String, List<String>> facets) {
+        this.facets = facets;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceCompanyEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceCompanyEntity.java
@@ -1,0 +1,113 @@
+package com.vibe.jobs.datasource.infrastructure.jpa;
+
+import com.vibe.jobs.datasource.infrastructure.jpa.converter.JsonStringMapConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Entity
+@Table(name = "job_data_source_company")
+public class JobDataSourceCompanyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "data_source_id", nullable = false)
+    private JobDataSourceEntity dataSource;
+
+    @Column(nullable = false)
+    private String reference;
+
+    @Column(name = "display_name")
+    private String displayName;
+
+    @Column
+    private String slug;
+
+    @Column(nullable = false)
+    private boolean enabled = true;
+
+    @Column(name = "placeholder_overrides", columnDefinition = "text")
+    @Convert(converter = JsonStringMapConverter.class)
+    private Map<String, String> placeholderOverrides = new LinkedHashMap<>();
+
+    @Column(name = "override_options", columnDefinition = "text")
+    @Convert(converter = JsonStringMapConverter.class)
+    private Map<String, String> overrideOptions = new LinkedHashMap<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public JobDataSourceEntity getDataSource() {
+        return dataSource;
+    }
+
+    public void setDataSource(JobDataSourceEntity dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(String reference) {
+        this.reference = reference;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getSlug() {
+        return slug;
+    }
+
+    public void setSlug(String slug) {
+        this.slug = slug;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Map<String, String> getPlaceholderOverrides() {
+        return placeholderOverrides;
+    }
+
+    public void setPlaceholderOverrides(Map<String, String> placeholderOverrides) {
+        this.placeholderOverrides = placeholderOverrides;
+    }
+
+    public Map<String, String> getOverrideOptions() {
+        return overrideOptions;
+    }
+
+    public void setOverrideOptions(Map<String, String> overrideOptions) {
+        this.overrideOptions = overrideOptions;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JobDataSourceEntity.java
@@ -1,0 +1,138 @@
+package com.vibe.jobs.datasource.infrastructure.jpa;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.infrastructure.jpa.converter.JsonStringMapConverter;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Entity
+@Table(name = "job_data_source")
+public class JobDataSourceEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String code;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column(name = "run_on_startup", nullable = false)
+    private boolean runOnStartup;
+
+    @Column(name = "require_override", nullable = false)
+    private boolean requireOverride;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JobDataSource.Flow flow = JobDataSource.Flow.UNLIMITED;
+
+    @Column(name = "base_options", columnDefinition = "text")
+    @jakarta.persistence.Convert(converter = JsonStringMapConverter.class)
+    private Map<String, String> baseOptions = new LinkedHashMap<>();
+
+    @OneToMany(mappedBy = "dataSource", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<JobDataSourceCompanyEntity> companies = new ArrayList<>();
+
+    @OneToMany(mappedBy = "dataSource", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<JobDataSourceCategoryEntity> categories = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isRunOnStartup() {
+        return runOnStartup;
+    }
+
+    public void setRunOnStartup(boolean runOnStartup) {
+        this.runOnStartup = runOnStartup;
+    }
+
+    public boolean isRequireOverride() {
+        return requireOverride;
+    }
+
+    public void setRequireOverride(boolean requireOverride) {
+        this.requireOverride = requireOverride;
+    }
+
+    public JobDataSource.Flow getFlow() {
+        return flow;
+    }
+
+    public void setFlow(JobDataSource.Flow flow) {
+        this.flow = flow;
+    }
+
+    public Map<String, String> getBaseOptions() {
+        return baseOptions;
+    }
+
+    public void setBaseOptions(Map<String, String> baseOptions) {
+        this.baseOptions = baseOptions;
+    }
+
+    public List<JobDataSourceCompanyEntity> getCompanies() {
+        return companies;
+    }
+
+    public void setCompanies(List<JobDataSourceCompanyEntity> companies) {
+        this.companies = companies;
+    }
+
+    public List<JobDataSourceCategoryEntity> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(List<JobDataSourceCategoryEntity> categories) {
+        this.categories = categories;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
@@ -1,0 +1,164 @@
+package com.vibe.jobs.datasource.infrastructure.jpa;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSourceRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Repository
+public class JpaJobDataSourceRepository implements JobDataSourceRepository {
+
+    private final SpringDataJobDataSourceRepository delegate;
+
+    public JpaJobDataSourceRepository(SpringDataJobDataSourceRepository delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public List<JobDataSource> findAllEnabled() {
+        return delegate.findAllEnabled().stream()
+                .map(this::toDomain)
+                .sorted(Comparator.comparing(JobDataSource::getCode))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<JobDataSource> findAll() {
+        return delegate.findAll().stream()
+                .map(this::toDomain)
+                .sorted(Comparator.comparing(JobDataSource::getCode))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<JobDataSource> findById(Long id) {
+        return delegate.findById(id).map(this::toDomain);
+    }
+
+    @Override
+    @Transactional
+    public JobDataSource save(JobDataSource dataSource) {
+        JobDataSourceEntity entity = toEntity(dataSource);
+        JobDataSourceEntity saved = delegate.save(entity);
+        return toDomain(saved);
+    }
+
+    @Override
+    @Transactional
+    public void saveAll(Collection<JobDataSource> sources) {
+        List<JobDataSourceEntity> entities = sources.stream()
+                .map(this::toEntity)
+                .collect(Collectors.toList());
+        delegate.saveAll(entities);
+    }
+
+    @Override
+    public boolean existsAny() {
+        return delegate.count() > 0;
+    }
+
+    private JobDataSource toDomain(JobDataSourceEntity entity) {
+        List<JobDataSource.DataSourceCompany> companies = entity.getCompanies().stream()
+                .map(company -> new JobDataSource.DataSourceCompany(
+                        company.getId(),
+                        company.getReference(),
+                        company.getDisplayName(),
+                        company.getSlug(),
+                        company.isEnabled(),
+                        safeMap(company.getPlaceholderOverrides()),
+                        safeMap(company.getOverrideOptions())
+                ))
+                .sorted(Comparator.comparing(JobDataSource.DataSourceCompany::reference))
+                .toList();
+
+        List<JobDataSource.CategoryQuotaDefinition> categories = entity.getCategories().stream()
+                .sorted(Comparator.comparing(JobDataSourceCategoryEntity::getName))
+                .map(category -> new JobDataSource.CategoryQuotaDefinition(
+                        category.getName(),
+                        category.getLimit(),
+                        safeList(category.getTags()),
+                        safeMapList(category.getFacets())
+                ))
+                .toList();
+
+        return new JobDataSource(
+                entity.getId(),
+                entity.getCode(),
+                entity.getType(),
+                entity.isEnabled(),
+                entity.isRunOnStartup(),
+                entity.isRequireOverride(),
+                entity.getFlow(),
+                safeMap(entity.getBaseOptions()),
+                categories,
+                companies
+        );
+    }
+
+    private JobDataSourceEntity toEntity(JobDataSource dataSource) {
+        JobDataSourceEntity entity = dataSource.getId() == null
+                ? new JobDataSourceEntity()
+                : delegate.findById(dataSource.getId()).orElse(new JobDataSourceEntity());
+        entity.setId(dataSource.getId());
+        entity.setCode(dataSource.getCode());
+        entity.setType(dataSource.getType());
+        entity.setEnabled(dataSource.isEnabled());
+        entity.setRunOnStartup(dataSource.isRunOnStartup());
+        entity.setRequireOverride(dataSource.isRequireOverride());
+        entity.setFlow(dataSource.getFlow());
+        entity.setBaseOptions(new LinkedHashMap<>(dataSource.getBaseOptions()));
+
+        entity.getCompanies().clear();
+        for (JobDataSource.DataSourceCompany company : dataSource.getCompanies()) {
+            JobDataSourceCompanyEntity companyEntity = new JobDataSourceCompanyEntity();
+            companyEntity.setId(null);
+            companyEntity.setDataSource(entity);
+            companyEntity.setReference(company.reference());
+            companyEntity.setDisplayName(company.displayName());
+            companyEntity.setSlug(company.slug());
+            companyEntity.setEnabled(company.enabled());
+            companyEntity.setPlaceholderOverrides(new LinkedHashMap<>(company.placeholderOverrides()));
+            companyEntity.setOverrideOptions(new LinkedHashMap<>(company.overrideOptions()));
+            entity.getCompanies().add(companyEntity);
+        }
+
+        entity.getCategories().clear();
+        for (JobDataSource.CategoryQuotaDefinition category : dataSource.getCategories()) {
+            JobDataSourceCategoryEntity categoryEntity = new JobDataSourceCategoryEntity();
+            categoryEntity.setId(null);
+            categoryEntity.setDataSource(entity);
+            categoryEntity.setName(category.name());
+            categoryEntity.setLimit(category.limit());
+            categoryEntity.setTags(category.tags());
+            categoryEntity.setFacets(category.facets());
+            entity.getCategories().add(categoryEntity);
+        }
+
+        return entity;
+    }
+
+    private Map<String, String> safeMap(Map<String, String> source) {
+        return source == null ? Map.of() : new LinkedHashMap<>(source);
+    }
+
+    private Map<String, List<String>> safeMapList(Map<String, List<String>> source) {
+        if (source == null) {
+            return Map.of();
+        }
+        Map<String, List<String>> copy = new LinkedHashMap<>();
+        source.forEach((key, value) -> copy.put(key, value == null ? List.of() : List.copyOf(value)));
+        return copy;
+    }
+
+    private List<String> safeList(List<String> source) {
+        return source == null ? List.of() : List.copyOf(source);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/SpringDataJobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/SpringDataJobDataSourceRepository.java
@@ -1,0 +1,18 @@
+package com.vibe.jobs.datasource.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SpringDataJobDataSourceRepository extends JpaRepository<JobDataSourceEntity, Long> {
+
+    @EntityGraph(attributePaths = {"companies", "categories"})
+    @Query("select distinct ds from JobDataSourceEntity ds where ds.enabled = true")
+    List<JobDataSourceEntity> findAllEnabled();
+
+    @Override
+    @EntityGraph(attributePaths = {"companies", "categories"})
+    List<JobDataSourceEntity> findAll();
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/AbstractJsonAttributeConverter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/AbstractJsonAttributeConverter.java
@@ -1,0 +1,48 @@
+package com.vibe.jobs.datasource.infrastructure.jpa.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Converter
+public abstract class AbstractJsonAttributeConverter<T> implements AttributeConverter<T, String> {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractJsonAttributeConverter.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final TypeReference<T> typeReference;
+
+    protected AbstractJsonAttributeConverter(TypeReference<T> typeReference) {
+        this.typeReference = typeReference;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(T attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize attribute {}", attribute, e);
+            return null;
+        }
+    }
+
+    @Override
+    public T convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return null;
+        }
+        try {
+            return OBJECT_MAPPER.readValue(dbData, typeReference);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to deserialize attribute {}", dbData, e);
+            return null;
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringListConverter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringListConverter.java
@@ -1,0 +1,14 @@
+package com.vibe.jobs.datasource.infrastructure.jpa.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+
+@Converter(autoApply = true)
+public class JsonStringListConverter extends AbstractJsonAttributeConverter<List<String>> {
+
+    public JsonStringListConverter() {
+        super(new TypeReference<>() {});
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringListMapConverter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringListMapConverter.java
@@ -1,0 +1,15 @@
+package com.vibe.jobs.datasource.infrastructure.jpa.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.persistence.Converter;
+
+import java.util.List;
+import java.util.Map;
+
+@Converter(autoApply = true)
+public class JsonStringListMapConverter extends AbstractJsonAttributeConverter<Map<String, List<String>>> {
+
+    public JsonStringListMapConverter() {
+        super(new TypeReference<>() {});
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringMapConverter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/converter/JsonStringMapConverter.java
@@ -1,0 +1,14 @@
+package com.vibe.jobs.datasource.infrastructure.jpa.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.persistence.Converter;
+
+import java.util.Map;
+
+@Converter(autoApply = true)
+public class JsonStringMapConverter extends AbstractJsonAttributeConverter<Map<String, String>> {
+
+    public JsonStringMapConverter() {
+        super(new TypeReference<>() {});
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/CareersApiStartupRunner.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/CareersApiStartupRunner.java
@@ -63,7 +63,7 @@ public class CareersApiStartupRunner implements ApplicationRunner {
         List<SourceRegistry.ConfiguredSource> limited = new ArrayList<>();
         List<SourceRegistry.ConfiguredSource> unlimited = new ArrayList<>();
         for (SourceRegistry.ConfiguredSource source : startupSources) {
-            if (source.definition().isLimitedFlow()) {
+            if (source.isLimitedFlow()) {
                 limited.add(source);
             } else {
                 unlimited.add(source);

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionFilter.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionFilter.java
@@ -1,6 +1,7 @@
 package com.vibe.jobs.ingestion;
 
 import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.datasource.application.DataSourceQueryService;
 import com.vibe.jobs.domain.Job;
 import com.vibe.jobs.sources.FetchedJob;
 import org.springframework.stereotype.Component;
@@ -16,9 +17,11 @@ import java.util.Set;
 public class JobIngestionFilter {
 
     private final IngestionProperties properties;
+    private final DataSourceQueryService queryService;
 
-    public JobIngestionFilter(IngestionProperties properties) {
+    public JobIngestionFilter(IngestionProperties properties, DataSourceQueryService queryService) {
         this.properties = properties;
+        this.queryService = queryService;
     }
 
     public List<FetchedJob> apply(List<FetchedJob> jobs) {
@@ -28,7 +31,7 @@ public class JobIngestionFilter {
 
         IngestionProperties.Mode mode = properties.getMode();
         if (mode == IngestionProperties.Mode.COMPANIES) {
-            Set<String> allowedCompanies = new HashSet<>(properties.normalizedCompanies());
+            Set<String> allowedCompanies = new HashSet<>(queryService.getNormalizedCompanyNames());
             if (allowedCompanies.isEmpty()) {
                 return jobs; // nothing to filter against
             }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionScheduler.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/JobIngestionScheduler.java
@@ -66,7 +66,7 @@ public class JobIngestionScheduler {
         List<SourceRegistry.ConfiguredSource> limited = new ArrayList<>();
         List<SourceRegistry.ConfiguredSource> unlimited = new ArrayList<>();
         for (SourceRegistry.ConfiguredSource source : sources) {
-            if (source.definition().isLimitedFlow()) {
+            if (source.isLimitedFlow()) {
                 limited.add(source);
             } else {
                 unlimited.add(source);

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
@@ -1,6 +1,11 @@
 package com.vibe.jobs.ingestion;
 
-import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.datasource.application.DataSourceQueryService;
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSource.CategoryQuotaDefinition;
+import com.vibe.jobs.datasource.domain.JobDataSource.DataSourceCompany;
+import com.vibe.jobs.datasource.domain.PlaceholderContext;
+import com.vibe.jobs.datasource.domain.SourceOptionDefaults;
 import com.vibe.jobs.sources.SourceClient;
 import com.vibe.jobs.sources.SourceClientFactory;
 import org.slf4j.Logger;
@@ -8,12 +13,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -21,185 +24,145 @@ public class SourceRegistry {
 
     private static final Logger log = LoggerFactory.getLogger(SourceRegistry.class);
 
-    private final IngestionProperties properties;
+    private final DataSourceQueryService queryService;
     private final SourceClientFactory factory;
     private final Map<String, SourceClient> clientCache = new ConcurrentHashMap<>();
 
-    public SourceRegistry(IngestionProperties properties, SourceClientFactory factory) {
-        this.properties = properties;
+    public SourceRegistry(DataSourceQueryService queryService, SourceClientFactory factory) {
+        this.queryService = queryService;
         this.factory = factory;
     }
 
     public List<ConfiguredSource> getScheduledSources() {
-        return resolveSources(false);
+        return resolveSources(queryService.fetchAllEnabled());
     }
 
     public List<ConfiguredSource> getStartupSources() {
-        return resolveSources(true);
+        return resolveSources(queryService.fetchStartupSources());
     }
 
-    private List<ConfiguredSource> resolveSources(boolean startupOnly) {
+    private List<ConfiguredSource> resolveSources(List<JobDataSource> sources) {
         List<ConfiguredSource> resolved = new ArrayList<>();
-        for (IngestionProperties.Source source : properties.getSources()) {
-            if (!source.isEnabled()) {
+        for (JobDataSource source : sources) {
+            if (source == null || !source.isEnabled()) {
                 continue;
             }
-            if (startupOnly && !source.isRunOnStartup()) {
-                continue;
-            }
-
             String type = source.getType();
             if (type == null || type.isBlank()) {
                 continue;
             }
 
-            // 检查是否为单实例API客户端（如Amazon官方API）
-            if (isSingleInstanceApiClient(type)) {
-                // 对于单实例客户端，不需要遍历公司列表，只创建一个实例
-                String cacheKey = source.key();
-                PlaceholderContext context = buildPlaceholderContext("");
-                Map<String, String> mergedOptions = source.getOptions();
-                List<CategoryQuota> categories = resolveCategories(source, context);
-                try {
-                    SourceClient client = clientCache.computeIfAbsent(cacheKey, key -> factory.create(type, mergedOptions));
-                    resolved.add(new ConfiguredSource(source, type.toUpperCase(), client, categories));
-                } catch (Exception ex) {
-                    log.warn("Failed to initialize single-instance source {}: {}", source.displayName(), ex.getMessage());
-                    log.debug("Source initialization error", ex);
-                }
-                continue;
-            }
-
-            // 对于公司特定的客户端，遍历公司列表
-            for (String companyName : properties.getCompanies()) {
-                if (companyName == null || companyName.isBlank()) {
-                    continue;
-                }
-                String trimmedCompany = companyName.trim();
-                PlaceholderContext context = buildPlaceholderContext(trimmedCompany);
-                Map<String, String> mergedOptions = mergeOptions(type, source, trimmedCompany, context);
-                if (mergedOptions.isEmpty()) {
-                    continue;
-                }
-                String cacheKey = source.key() + "::" + trimmedCompany;
-                List<CategoryQuota> categories = resolveCategories(source, context);
-                try {
-                    SourceClient client = clientCache.computeIfAbsent(cacheKey, key -> factory.create(type, mergedOptions));
-                    resolved.add(new ConfiguredSource(source, trimmedCompany, client, categories));
-                } catch (Exception ex) {
-                    log.warn("Failed to initialize source {} for company {}: {}", source.displayName(), trimmedCompany, ex.getMessage());
-                    log.debug("Source initialization error", ex);
-                }
+            if (isSingleInstanceApiClient(type) || !source.supportsCompanies()) {
+                resolved.addAll(resolveSingleInstance(source));
+            } else {
+                resolved.addAll(resolvePerCompany(source));
             }
         }
         return resolved;
     }
-    
-    /**
-     * 判断是否为单实例API客户端
-     */
-    private boolean isSingleInstanceApiClient(String type) {
-        if (type == null) return false;
-        String normalized = type.toLowerCase(Locale.ROOT);
-        return normalized.equals("apple-api") || 
-               normalized.equals("microsoft-api") || 
-               normalized.equals("amazon-api") ||
-               normalized.endsWith("-api");  // 通用规则：以-api结尾的都视为单实例客户端
-    }
 
-    public record ConfiguredSource(IngestionProperties.Source definition,
-                                   String company,
-                                   SourceClient client,
-                                   List<CategoryQuota> categories) {
-        public ConfiguredSource {
-            categories = categories == null ? List.of() : List.copyOf(categories);
+    private List<ConfiguredSource> resolveSingleInstance(JobDataSource source) {
+        List<ConfiguredSource> result = new ArrayList<>();
+        PlaceholderContext context = PlaceholderContext.forCompany(null);
+        Map<String, String> options = mergeOptions(source, null, context);
+        List<CategoryQuota> categories = resolveCategories(source, context);
+        if (options.isEmpty()) {
+            return result;
         }
-    }
-
-    public record CategoryQuota(String name,
-                                int limit,
-                                List<String> tags,
-                                Map<String, List<String>> facets) {
-        public CategoryQuota {
-            tags = tags == null ? List.of() : List.copyOf(tags);
-            Map<String, List<String>> normalized = new LinkedHashMap<>();
-            if (facets != null) {
-                facets.forEach((key, values) -> {
-                    List<String> copy = values == null ? List.of() : List.copyOf(values);
-                    normalized.put(key, copy);
-                });
-            }
-            facets = normalized.isEmpty() ? Map.of() : Map.copyOf(normalized);
+        String cacheKey = cacheKey(source.getCode(), "single");
+        try {
+            SourceClient client = clientCache.computeIfAbsent(cacheKey, key -> factory.create(source.getType(), options));
+            result.add(new ConfiguredSource(source, source.getCode(), client, categories));
+        } catch (Exception ex) {
+            log.warn("Failed to initialize single-instance source {}: {}", source.getCode(), ex.getMessage());
+            log.debug("Source initialization error", ex);
         }
-
-        public boolean hasFacets() {
-            return !facets.isEmpty();
-        }
-    }
-
-    private Map<String, String> mergeOptions(String type,
-                                             IngestionProperties.Source source,
-                                             String companyName,
-                                             PlaceholderContext context) {
-        IngestionProperties.SourceOverride override = properties.getSourceOverride(companyName, type);
-
-        if (override != null && !override.isEnabled()) {
-            return Map.of();
-        }
-        if (source.isRequireOverride() && override == null) {
-            return Map.of();
-        }
-
-        Map<String, String> overrideOptions = override == null ? Map.of() : override.optionsCopy();
-
-        Map<String, String> result = new HashMap<>(source.getOptions());
-        result.replaceAll((k, v) -> applyPlaceholders(v, context));
-
-        Map<String, String> derived = deriveDefaults(type, context);
-        derived.forEach(result::putIfAbsent);
-
-        overrideOptions.forEach(result::put);
-
-        if (!context.company().isBlank()) {
-            result.putIfAbsent("company", context.company());
-        }
-
-        result.replaceAll((k, v) -> applyPlaceholders(v, context));
-
-        result.values().removeIf(value -> value == null || value.isBlank());
-
         return result;
     }
 
-    private List<CategoryQuota> resolveCategories(IngestionProperties.Source source, PlaceholderContext context) {
-        List<IngestionProperties.Source.CategoryQuota> configured = source.getCategories();
-        if (configured == null || configured.isEmpty()) {
+    private List<ConfiguredSource> resolvePerCompany(JobDataSource source) {
+        List<ConfiguredSource> resolved = new ArrayList<>();
+        for (DataSourceCompany company : source.getCompanies()) {
+            if (company == null || !company.enabled()) {
+                continue;
+            }
+            PlaceholderContext context = PlaceholderContext.forCompany(company);
+            Map<String, String> options = mergeOptions(source, company, context);
+            if (options.isEmpty()) {
+                continue;
+            }
+            List<CategoryQuota> categories = resolveCategories(source, context);
+            String companyKey = company.reference().isBlank() ? company.displayName() : company.reference();
+            String cacheKey = cacheKey(source.getCode(), companyKey);
+            try {
+                SourceClient client = clientCache.computeIfAbsent(cacheKey, key -> factory.create(source.getType(), options));
+                resolved.add(new ConfiguredSource(source, context.company(), client, categories));
+            } catch (Exception ex) {
+                log.warn("Failed to initialize source {} for company {}: {}", source.getCode(), context.company(), ex.getMessage());
+                log.debug("Source initialization error", ex);
+            }
+        }
+        return resolved;
+    }
+
+    private String cacheKey(String sourceCode, String company) {
+        return (sourceCode == null ? "" : sourceCode) + "::" + (company == null ? "" : company.toLowerCase(Locale.ROOT));
+    }
+
+    private Map<String, String> mergeOptions(JobDataSource source,
+                                             DataSourceCompany company,
+                                             PlaceholderContext context) {
+        Map<String, String> merged = new LinkedHashMap<>(source.getBaseOptions());
+        merged.replaceAll((k, v) -> applyPlaceholders(v, context));
+
+        Map<String, String> defaults = SourceOptionDefaults.derive(source.getType(), context);
+        defaults.forEach((key, value) -> {
+            if (value != null && !value.isBlank()) {
+                merged.putIfAbsent(key, value);
+            }
+        });
+
+        Map<String, String> overrideOptions = company == null ? Map.of() : company.overrideOptions();
+        if (source.isRequireOverride() && overrideOptions.isEmpty()) {
+            return Map.of();
+        }
+        overrideOptions.forEach((key, value) -> {
+            if (value != null && !value.isBlank()) {
+                merged.put(key, context.apply(value));
+            }
+        });
+
+        if (!context.company().isBlank()) {
+            merged.putIfAbsent("company", context.company());
+        }
+        merged.replaceAll((k, v) -> applyPlaceholders(v, context));
+        merged.values().removeIf(value -> value == null || value.isBlank());
+        return merged;
+    }
+
+    private List<CategoryQuota> resolveCategories(JobDataSource source, PlaceholderContext context) {
+        List<CategoryQuotaDefinition> definitions = source.getCategories();
+        if (definitions == null || definitions.isEmpty()) {
             return List.of();
         }
         List<CategoryQuota> result = new ArrayList<>();
-        for (IngestionProperties.Source.CategoryQuota quota : configured) {
-            if (quota == null) {
+        int index = 1;
+        for (CategoryQuotaDefinition definition : definitions) {
+            if (definition == null || definition.limit() <= 0) {
                 continue;
             }
-            int limit = Math.max(quota.getLimit(), 0);
-            if (limit <= 0) {
-                continue;
-            }
-            String name = applyPlaceholders(quota.getName(), context);
+            String name = applyPlaceholders(definition.name(), context);
             if (name == null || name.isBlank()) {
-                name = "category-" + (result.size() + 1);
+                name = "category-" + index++;
             }
-
-            List<String> tags = quota.getTags() == null ? List.of() : quota.getTags().stream()
+            List<String> tags = definition.tags() == null ? List.of() : definition.tags().stream()
                     .map(tag -> applyPlaceholders(tag, context))
                     .filter(tag -> tag != null && !tag.isBlank())
                     .map(tag -> tag.trim().toLowerCase(Locale.ROOT))
                     .distinct()
                     .toList();
-
-            Map<String, List<String>> facets = resolveFacets(quota.getFacets(), context);
-
-            result.add(new CategoryQuota(name, limit, tags, facets));
+            Map<String, List<String>> facets = resolveFacets(definition.facets(), context);
+            result.add(new CategoryQuota(name, definition.limit(), tags, facets));
         }
         return result;
     }
@@ -230,104 +193,55 @@ public class SourceRegistry {
         return resolved.isEmpty() ? Map.of() : Map.copyOf(resolved);
     }
 
-    private Map<String, String> deriveDefaults(String type, PlaceholderContext context) {
-        if (context.company().isBlank()) {
-            return Map.of();
-        }
-        String normalized = context.slug();
-        if (normalized.isBlank()) {
-            return Map.of();
-        }
-        return switch (type.toLowerCase(Locale.ROOT)) {
-            case "greenhouse" -> Map.of("slug", normalized);
-            case "lever" -> Map.of("company", normalized);
-            case "workday" -> Map.of(
-                    "baseUrl", "https://" + normalized + ".wd1.myworkdayjobs.com",
-                    "tenant", normalized,
-                    "site", context.slugUpper()
-            );
-            case "ashby" -> Map.of(
-                    "company", context.company(),
-                    "baseUrl", "https://jobs.ashbyhq.com/" + normalized
-            );
-            case "smartrecruiters" -> Map.of(
-                    "company", context.company()
-            );
-            case "recruitee" -> Map.of(
-                    "company", normalized
-            );
-            case "workable" -> Map.of(
-                    "company", normalized
-            );
-            default -> Map.of();
-        };
-    }
-
     private String applyPlaceholders(String value, PlaceholderContext context) {
         if (value == null) {
             return null;
         }
-        String result = value
-                .replace("{{company}}", context.company())
-                .replace("{{companyLower}}", context.companyLower())
-                .replace("{{companyUpper}}", context.companyUpper())
-                .replace("{{slug}}", context.slug())
-                .replace("{{slugUpper}}", context.slugUpper());
-        for (Map.Entry<String, String> entry : context.custom().entrySet()) {
-            result = result.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        return context.apply(value);
+    }
+
+    private boolean isSingleInstanceApiClient(String type) {
+        if (type == null) {
+            return false;
         }
-        return result;
+        String normalized = type.toLowerCase(Locale.ROOT);
+        return normalized.equals("apple-api") ||
+                normalized.equals("microsoft-api") ||
+                normalized.equals("amazon-api") ||
+                normalized.endsWith("-api");
     }
 
-    private PlaceholderContext buildPlaceholderContext(String companyName) {
-        String trimmed = Objects.requireNonNullElse(companyName, "").trim();
-        Map<String, String> overrides = new LinkedHashMap<>(properties.getPlaceholderOverrides(trimmed));
+    public record ConfiguredSource(JobDataSource definition,
+                                   String company,
+                                   SourceClient client,
+                                   List<CategoryQuota> categories) {
+        public ConfiguredSource {
+            categories = categories == null ? List.of() : List.copyOf(categories);
+        }
 
-        String company = overrides.containsKey("company")
-                ? overrides.remove("company")
-                : trimmed;
-        company = company == null ? "" : company.trim();
-
-        String slug = overrides.containsKey("slug")
-                ? overrides.remove("slug")
-                : slugify(company.isBlank() ? trimmed : company);
-        slug = slug == null ? "" : slug.trim();
-
-        String slugUpper = overrides.containsKey("slugUpper")
-                ? overrides.remove("slugUpper")
-                : slug.toUpperCase(Locale.ROOT);
-        slugUpper = slugUpper == null ? "" : slugUpper.trim();
-
-        String companyLower = overrides.containsKey("companyLower")
-                ? overrides.remove("companyLower")
-                : company.toLowerCase(Locale.ROOT);
-        companyLower = companyLower == null ? "" : companyLower.trim();
-
-        String companyUpper = overrides.containsKey("companyUpper")
-                ? overrides.remove("companyUpper")
-                : company.toUpperCase(Locale.ROOT);
-        companyUpper = companyUpper == null ? "" : companyUpper.trim();
-
-        return new PlaceholderContext(
-                company,
-                companyLower,
-                companyUpper,
-                slug,
-                slugUpper,
-                overrides
-        );
+        public boolean isLimitedFlow() {
+            return definition != null && definition.isLimitedFlow();
+        }
     }
 
-    private record PlaceholderContext(String company,
-                                      String companyLower,
-                                      String companyUpper,
-                                      String slug,
-                                      String slugUpper,
-                                      Map<String, String> custom) { }
+    public record CategoryQuota(String name,
+                                int limit,
+                                List<String> tags,
+                                Map<String, List<String>> facets) {
+        public CategoryQuota {
+            tags = tags == null ? List.of() : List.copyOf(tags);
+            Map<String, List<String>> normalized = new LinkedHashMap<>();
+            if (facets != null) {
+                facets.forEach((key, values) -> {
+                    List<String> copy = values == null ? List.of() : List.copyOf(values);
+                    normalized.put(key, copy);
+                });
+            }
+            facets = normalized.isEmpty() ? Map.of() : Map.copyOf(normalized);
+        }
 
-    private String slugify(String value) {
-        return value.toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9]+", "-")
-                .replaceAll("^-|-$", "");
+        public boolean hasFacets() {
+            return !facets.isEmpty();
+        }
     }
 }

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V4__create_job_datasource_tables.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V4__create_job_datasource_tables.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS job_data_source (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    code VARCHAR(128) NOT NULL UNIQUE,
+    type VARCHAR(128) NOT NULL,
+    enabled BIT NOT NULL DEFAULT 1,
+    run_on_startup BIT NOT NULL DEFAULT 1,
+    require_override BIT NOT NULL DEFAULT 0,
+    flow VARCHAR(16) NOT NULL DEFAULT 'UNLIMITED',
+    base_options TEXT
+);
+
+CREATE TABLE IF NOT EXISTS job_data_source_company (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    data_source_id BIGINT NOT NULL,
+    reference VARCHAR(255) NOT NULL,
+    display_name VARCHAR(255),
+    slug VARCHAR(255),
+    enabled BIT NOT NULL DEFAULT 1,
+    placeholder_overrides TEXT,
+    override_options TEXT,
+    CONSTRAINT fk_job_data_source_company_source FOREIGN KEY (data_source_id) REFERENCES job_data_source (id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_job_data_source_company_source ON job_data_source_company (data_source_id);
+
+CREATE TABLE IF NOT EXISTS job_data_source_category (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    data_source_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    quota_limit INT NOT NULL,
+    tags TEXT,
+    facets TEXT,
+    CONSTRAINT fk_job_data_source_category_source FOREIGN KEY (data_source_id) REFERENCES job_data_source (id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_job_data_source_category_source ON job_data_source_category (data_source_id);


### PR DESCRIPTION
## Summary
- introduce a dedicated data source domain model with JPA entities, repositories, and JSON converters
- load enabled job data sources from the database for scheduling and startup ingestion, applying placeholder-aware option merging
- migrate legacy YAML ingestion configuration into the new tables on first startup and add Flyway DDL for the new schema

## Testing
- `mvn test` *(fails: unable to download parent POM from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd140e66a8832881f57de82efcaec8