### PR TITLE
Add crawler blueprint domain and integrate new source type

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/CrawlerCommandService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/CrawlerCommandService.java
@@ -1,0 +1,33 @@
+package com.vibe.jobs.crawler.application;
+
+import com.vibe.jobs.crawler.domain.CrawlBlueprint;
+import com.vibe.jobs.crawler.domain.CrawlerBlueprintRepository;
+import com.vibe.jobs.crawler.domain.CrawlerParserTemplateRepository;
+import com.vibe.jobs.crawler.domain.ParserProfile;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class CrawlerCommandService {
+
+    private final CrawlerBlueprintRepository blueprintRepository;
+    private final CrawlerParserTemplateRepository templateRepository;
+
+    public CrawlerCommandService(CrawlerBlueprintRepository blueprintRepository,
+                                 CrawlerParserTemplateRepository templateRepository) {
+        this.blueprintRepository = blueprintRepository;
+        this.templateRepository = templateRepository;
+    }
+
+    public Optional<CrawlBlueprint> findBlueprint(String code) {
+        return blueprintRepository.findByCode(code);
+    }
+
+    public ParserProfile resolveParser(String templateCode, ParserProfile fallback) {
+        if (templateCode == null || templateCode.isBlank()) {
+            return fallback;
+        }
+        return templateRepository.findByCode(templateCode).orElse(fallback);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/CrawlerOrchestrator.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/CrawlerOrchestrator.java
@@ -1,0 +1,99 @@
+package com.vibe.jobs.crawler.application;
+
+import com.vibe.jobs.crawler.application.dto.CrawlPageRequest;
+import com.vibe.jobs.crawler.application.dto.CrawlPageResult;
+import com.vibe.jobs.crawler.domain.*;
+import com.vibe.jobs.crawler.infrastructure.engine.CrawlPageSnapshot;
+import com.vibe.jobs.crawler.infrastructure.engine.CrawlerExecutionEngine;
+import com.vibe.jobs.crawler.infrastructure.parser.CrawlerParserEngine;
+import com.vibe.jobs.sources.FetchedJob;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+public class CrawlerOrchestrator {
+
+    private static final Logger log = LoggerFactory.getLogger(CrawlerOrchestrator.class);
+
+    private final CrawlerBlueprintRepository blueprintRepository;
+    private final CrawlRunRepository runRepository;
+    private final CrawlerExecutionEngine executionEngine;
+    private final CrawlerParserEngine parserEngine;
+    private final Clock clock;
+
+    public CrawlerOrchestrator(CrawlerBlueprintRepository blueprintRepository,
+                               CrawlRunRepository runRepository,
+                               CrawlerExecutionEngine executionEngine,
+                               CrawlerParserEngine parserEngine,
+                               java.util.Optional<Clock> clock) {
+        this.blueprintRepository = blueprintRepository;
+        this.runRepository = runRepository;
+        this.executionEngine = executionEngine;
+        this.parserEngine = parserEngine;
+        this.clock = clock.orElse(Clock.systemUTC());
+    }
+
+    public CrawlPageResult execute(CrawlPageRequest request) {
+        Objects.requireNonNull(request, "request");
+        Instant started = clock.instant();
+        CrawlBlueprint blueprint = blueprintRepository.findByCode(request.blueprintCode())
+                .orElseThrow(() -> new IllegalArgumentException("Unknown crawler blueprint: " + request.blueprintCode()));
+        if (!blueprint.enabled() || !blueprint.isConfigured()) {
+            log.info("Crawler blueprint {} disabled or misconfigured", blueprint.code());
+            return new CrawlPageResult(List.of(), new CrawlMetrics(0, 0, request.pagination().page(), true, "disabled"));
+        }
+
+        CrawlSession session = new CrawlSession(blueprint, request.context());
+        List<CrawlResult> results = new ArrayList<>();
+        boolean success = false;
+        String error = "";
+        try {
+            CrawlPageSnapshot snapshot = executionEngine.fetch(session, request.pagination());
+            results = parserEngine.parse(session, snapshot);
+            success = true;
+        } catch (Exception ex) {
+            error = ex.getMessage() == null ? ex.toString() : ex.getMessage();
+            log.warn("Crawler execution failed for blueprint {} page {}: {}", blueprint.code(), request.pagination().page(), error);
+            log.debug("Crawler execution error", ex);
+        }
+        Instant completed = clock.instant();
+        long duration = Math.max(0, completed.toEpochMilli() - started.toEpochMilli());
+        CrawlMetrics metrics = new CrawlMetrics(duration, results.size(), request.pagination().page(), success, error);
+        recordRun(session, request.pagination(), metrics);
+        return new CrawlPageResult(results, metrics);
+    }
+
+    public List<FetchedJob> fetchJobs(String blueprintCode, CrawlContext context, int page, int size) {
+        CrawlPageResult result = execute(new CrawlPageRequest(blueprintCode, context, new CrawlPagination(page, size)));
+        return result.results().stream().map(CrawlResult::job).toList();
+    }
+
+    private void recordRun(CrawlSession session, CrawlPagination pagination, CrawlMetrics metrics) {
+        try {
+            CrawlRun run = new CrawlRun(
+                    UUID.randomUUID().toString(),
+                    session.blueprint().code(),
+                    session.context().dataSourceCode(),
+                    session.context().company(),
+                    pagination.page(),
+                    metrics.jobCount(),
+                    metrics.durationMs(),
+                    metrics.success(),
+                    metrics.error(),
+                    session.startedAt(),
+                    clock.instant()
+            );
+            runRepository.save(run);
+        } catch (Exception ex) {
+            log.debug("Failed to persist crawler run log: {}", ex.getMessage());
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/dto/CrawlPageRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/dto/CrawlPageRequest.java
@@ -1,0 +1,9 @@
+package com.vibe.jobs.crawler.application.dto;
+
+import com.vibe.jobs.crawler.domain.CrawlContext;
+import com.vibe.jobs.crawler.domain.CrawlPagination;
+
+public record CrawlPageRequest(String blueprintCode,
+                               CrawlContext context,
+                               CrawlPagination pagination) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/dto/CrawlPageResult.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/application/dto/CrawlPageResult.java
@@ -1,0 +1,12 @@
+package com.vibe.jobs.crawler.application.dto;
+
+import com.vibe.jobs.crawler.domain.CrawlMetrics;
+import com.vibe.jobs.crawler.domain.CrawlResult;
+
+import java.util.List;
+
+public record CrawlPageResult(List<CrawlResult> results, CrawlMetrics metrics) {
+    public CrawlPageResult {
+        results = results == null ? List.of() : List.copyOf(results);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlBlueprint.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlBlueprint.java
@@ -1,0 +1,128 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Aggregate root that describes how a specific career site should be crawled.
+ */
+public class CrawlBlueprint {
+
+    private final String code;
+    private final String name;
+    private final boolean enabled;
+    private final int concurrencyLimit;
+    private final String entryUrl;
+    private final PagingStrategy pagingStrategy;
+    private final CrawlFlow flow;
+    private final ParserProfile parserProfile;
+    private final RateLimit rateLimit;
+    private final Map<String, Object> metadata;
+
+    public CrawlBlueprint(String code,
+                          String name,
+                          boolean enabled,
+                          int concurrencyLimit,
+                          String entryUrl,
+                          PagingStrategy pagingStrategy,
+                          CrawlFlow flow,
+                          ParserProfile parserProfile,
+                          RateLimit rateLimit,
+                          Map<String, Object> metadata) {
+        this.code = sanitize(code);
+        this.name = sanitize(name);
+        this.enabled = enabled;
+        this.concurrencyLimit = concurrencyLimit <= 0 ? 1 : concurrencyLimit;
+        this.entryUrl = sanitize(entryUrl);
+        this.pagingStrategy = pagingStrategy == null ? PagingStrategy.disabled() : pagingStrategy;
+        this.flow = flow == null ? CrawlFlow.empty() : flow;
+        this.parserProfile = parserProfile == null ? ParserProfile.empty() : parserProfile;
+        this.rateLimit = rateLimit == null ? RateLimit.unlimited() : rateLimit;
+        this.metadata = metadata == null ? Map.of() : Collections.unmodifiableMap(metadata);
+    }
+
+    private String sanitize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public int concurrencyLimit() {
+        return concurrencyLimit;
+    }
+
+    public String entryUrl() {
+        return entryUrl;
+    }
+
+    public PagingStrategy pagingStrategy() {
+        return pagingStrategy;
+    }
+
+    public CrawlFlow flow() {
+        return flow;
+    }
+
+    public ParserProfile parserProfile() {
+        return parserProfile;
+    }
+
+    public RateLimit rateLimit() {
+        return rateLimit;
+    }
+
+    public Map<String, Object> metadata() {
+        return metadata;
+    }
+
+    public boolean isConfigured() {
+        return !entryUrl.isBlank() && parserProfile.isConfigured();
+    }
+
+    public String resolveEntryUrl(CrawlContext context, CrawlPagination pagination) {
+        Objects.requireNonNull(context, "context");
+        Objects.requireNonNull(pagination, "pagination");
+        String base = context.entryUrlOverride().filter(url -> !url.isBlank()).orElse(entryUrl);
+        if (base == null || base.isBlank()) {
+            return "";
+        }
+        return pagingStrategy.apply(base, pagination);
+    }
+
+    public boolean allowsParallelism() {
+        return concurrencyLimit > 1;
+    }
+
+    public Optional<Object> metadata(String key) {
+        if (key == null || key.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(metadata.get(key));
+    }
+
+    public record RateLimit(int requestsPerMinute, int burst) {
+        public static RateLimit of(int requestsPerMinute, int burst) {
+            return new RateLimit(Math.max(0, requestsPerMinute), Math.max(1, burst));
+        }
+
+        public static RateLimit unlimited() {
+            return new RateLimit(0, 1);
+        }
+
+        public boolean isLimited() {
+            return requestsPerMinute > 0;
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlContext.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlContext.java
@@ -1,0 +1,56 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public class CrawlContext {
+
+    private final String dataSourceCode;
+    private final String company;
+    private final String sourceName;
+    private final String entryUrlOverride;
+    private final Map<String, String> options;
+
+    public CrawlContext(String dataSourceCode,
+                        String company,
+                        String sourceName,
+                        String entryUrlOverride,
+                        Map<String, String> options) {
+        this.dataSourceCode = sanitize(dataSourceCode);
+        this.company = sanitize(company);
+        this.sourceName = sanitize(sourceName);
+        this.entryUrlOverride = entryUrlOverride == null ? "" : entryUrlOverride.trim();
+        this.options = options == null ? Map.of() : Collections.unmodifiableMap(options);
+    }
+
+    private String sanitize(String value) {
+        return value == null ? "" : value.trim();
+    }
+
+    public String dataSourceCode() {
+        return dataSourceCode;
+    }
+
+    public String company() {
+        return company;
+    }
+
+    public String sourceName() {
+        return sourceName;
+    }
+
+    public Optional<String> entryUrlOverride() {
+        return entryUrlOverride.isBlank() ? Optional.empty() : Optional.of(entryUrlOverride);
+    }
+
+    public Map<String, String> options() {
+        return options;
+    }
+
+    public String option(String key) {
+        Objects.requireNonNull(key, "key");
+        return options.getOrDefault(key, "");
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlFlow.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlFlow.java
@@ -1,0 +1,40 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CrawlFlow {
+
+    private final List<CrawlStep> steps;
+
+    private CrawlFlow(List<CrawlStep> steps) {
+        this.steps = steps == null ? List.of() : List.copyOf(steps);
+    }
+
+    public static CrawlFlow of(List<CrawlStep> steps) {
+        if (steps == null || steps.isEmpty()) {
+            return empty();
+        }
+        List<CrawlStep> normalized = new ArrayList<>();
+        for (CrawlStep step : steps) {
+            if (step == null) {
+                continue;
+            }
+            normalized.add(step);
+        }
+        return new CrawlFlow(Collections.unmodifiableList(normalized));
+    }
+
+    public static CrawlFlow empty() {
+        return new CrawlFlow(List.of());
+    }
+
+    public List<CrawlStep> steps() {
+        return steps;
+    }
+
+    public boolean isEmpty() {
+        return steps.isEmpty();
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlMetrics.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlMetrics.java
@@ -1,0 +1,7 @@
+package com.vibe.jobs.crawler.domain;
+
+public record CrawlMetrics(long durationMs, int jobCount, int pageIndex, boolean success, String error) {
+    public CrawlMetrics {
+        error = error == null ? "" : error;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlPagination.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlPagination.java
@@ -1,0 +1,15 @@
+package com.vibe.jobs.crawler.domain;
+
+public record CrawlPagination(int page, int size) {
+
+    public CrawlPagination {
+        int normalizedPage = Math.max(1, page);
+        int normalizedSize = Math.max(1, size);
+        this.page = normalizedPage;
+        this.size = normalizedSize;
+    }
+
+    public int offset() {
+        return (page - 1) * size;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlResult.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlResult.java
@@ -1,0 +1,11 @@
+package com.vibe.jobs.crawler.domain;
+
+import com.vibe.jobs.sources.FetchedJob;
+
+import java.util.Map;
+
+public record CrawlResult(FetchedJob job, String rawContent, Map<String, Object> metadata) {
+    public CrawlResult {
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlRun.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlRun.java
@@ -1,0 +1,16 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.time.Instant;
+
+public record CrawlRun(String id,
+                        String blueprintCode,
+                        String dataSourceCode,
+                        String company,
+                        int pageIndex,
+                        int jobCount,
+                        long durationMs,
+                        boolean success,
+                        String error,
+                        Instant startedAt,
+                        Instant completedAt) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlRunRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlRunRepository.java
@@ -1,0 +1,5 @@
+package com.vibe.jobs.crawler.domain;
+
+public interface CrawlRunRepository {
+    void save(CrawlRun run);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlSession.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlSession.java
@@ -1,0 +1,39 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public class CrawlSession {
+
+    private final String id;
+    private final CrawlBlueprint blueprint;
+    private final CrawlContext context;
+    private final Instant startedAt;
+
+    public CrawlSession(CrawlBlueprint blueprint, CrawlContext context) {
+        this(UUID.randomUUID().toString(), blueprint, context, Instant.now());
+    }
+
+    public CrawlSession(String id, CrawlBlueprint blueprint, CrawlContext context, Instant startedAt) {
+        this.id = id;
+        this.blueprint = blueprint;
+        this.context = context;
+        this.startedAt = startedAt == null ? Instant.now() : startedAt;
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public CrawlBlueprint blueprint() {
+        return blueprint;
+    }
+
+    public CrawlContext context() {
+        return context;
+    }
+
+    public Instant startedAt() {
+        return startedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlStep.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlStep.java
@@ -1,0 +1,26 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class CrawlStep {
+    private final CrawlStepType type;
+    private final Map<String, Object> options;
+
+    public CrawlStep(CrawlStepType type, Map<String, Object> options) {
+        this.type = type == null ? CrawlStepType.REQUEST : type;
+        this.options = options == null ? Map.of() : Collections.unmodifiableMap(options);
+    }
+
+    public static CrawlStep of(CrawlStepType type, Map<String, Object> options) {
+        return new CrawlStep(type, options);
+    }
+
+    public CrawlStepType type() {
+        return type;
+    }
+
+    public Map<String, Object> options() {
+        return options;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlStepType.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlStepType.java
@@ -1,0 +1,10 @@
+package com.vibe.jobs.crawler.domain;
+
+public enum CrawlStepType {
+    REQUEST,
+    WAIT,
+    SCROLL,
+    CLICK,
+    EXTRACT_LIST,
+    EXTRACT_DETAIL
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlerBlueprintRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlerBlueprintRepository.java
@@ -1,0 +1,9 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CrawlerBlueprintRepository {
+    Optional<CrawlBlueprint> findByCode(String code);
+    List<CrawlBlueprint> findAllEnabled();
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlerParserTemplateRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/CrawlerParserTemplateRepository.java
@@ -1,0 +1,7 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.util.Optional;
+
+public interface CrawlerParserTemplateRepository {
+    Optional<ParserProfile> findByCode(String code);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/PagingStrategy.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/PagingStrategy.java
@@ -1,0 +1,151 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+
+public class PagingStrategy {
+
+    public enum Mode {
+        NONE,
+        QUERY,
+        PATH_SUFFIX,
+        OFFSET
+    }
+
+    private final Mode mode;
+    private final String parameter;
+    private final int start;
+    private final int step;
+    private final String sizeParameter;
+
+    private PagingStrategy(Mode mode, String parameter, int start, int step, String sizeParameter) {
+        this.mode = mode;
+        this.parameter = parameter == null ? "" : parameter.trim();
+        this.start = start;
+        this.step = step <= 0 ? 1 : step;
+        this.sizeParameter = sizeParameter == null ? "" : sizeParameter.trim();
+    }
+
+    public static PagingStrategy disabled() {
+        return new PagingStrategy(Mode.NONE, "", 1, 1, "");
+    }
+
+    public static PagingStrategy query(String parameter, int start, int step, String sizeParameter) {
+        return new PagingStrategy(Mode.QUERY, parameter, start, step, sizeParameter);
+    }
+
+    public static PagingStrategy pathSuffix(int start, int step) {
+        return new PagingStrategy(Mode.PATH_SUFFIX, null, start, step, "");
+    }
+
+    public static PagingStrategy offset(String parameter, int start, int step, String sizeParameter) {
+        return new PagingStrategy(Mode.OFFSET, parameter, start, step, sizeParameter);
+    }
+
+    public String apply(String baseUrl, CrawlPagination pagination) {
+        if (baseUrl == null || baseUrl.isBlank() || pagination == null) {
+            return baseUrl;
+        }
+        try {
+            return switch (mode) {
+                case NONE -> baseUrl;
+                case QUERY -> applyQuery(baseUrl, pagination.page());
+                case PATH_SUFFIX -> applyPathSuffix(baseUrl, pagination.page());
+                case OFFSET -> applyOffset(baseUrl, pagination);
+            };
+        } catch (URISyntaxException e) {
+            return baseUrl;
+        }
+    }
+
+    private String applyQuery(String baseUrl, int page) throws URISyntaxException {
+        String param = parameter.isBlank() ? "page" : parameter;
+        URI uri = new URI(baseUrl);
+        String query = uri.getQuery();
+        int normalized = normalizePage(page);
+        String newQueryParam = param + "=" + normalized;
+        String updated = query == null || query.isBlank() ? newQueryParam : query + "&" + newQueryParam;
+        if (!sizeParameter.isBlank() && !updated.contains(sizeParameter + "=")) {
+            updated = updated + "&" + sizeParameter + "=" + Math.max(1, pagination.size());
+        }
+        return rebuildUri(uri, updated);
+    }
+
+    private String applyOffset(String baseUrl, CrawlPagination pagination) throws URISyntaxException {
+        String param = parameter.isBlank() ? "offset" : parameter;
+        URI uri = new URI(baseUrl);
+        String query = uri.getQuery();
+        int offset = (normalizePage(pagination.page()) - 1) * Math.max(1, pagination.size());
+        String newQueryParam = param + "=" + offset;
+        String updated = query == null || query.isBlank() ? newQueryParam : query + "&" + newQueryParam;
+        if (!sizeParameter.isBlank() && !updated.contains(sizeParameter + "=")) {
+            updated = updated + "&" + sizeParameter + "=" + Math.max(1, pagination.size());
+        }
+        return rebuildUri(uri, updated);
+    }
+
+    private String applyPathSuffix(String baseUrl, int page) {
+        int normalized = normalizePage(page);
+        if (baseUrl.endsWith("/")) {
+            return baseUrl + normalized;
+        }
+        return baseUrl + "/" + normalized;
+    }
+
+    private String rebuildUri(URI uri, String query) throws URISyntaxException {
+        return new URI(
+                uri.getScheme(),
+                uri.getAuthority(),
+                uri.getPath(),
+                query,
+                uri.getFragment())
+                .toString();
+    }
+
+    private int normalizePage(int page) {
+        int normalized = Math.max(1, page);
+        int value = start + ((normalized - 1) * step);
+        if (mode == Mode.OFFSET) {
+            return value;
+        }
+        return Math.max(1, value);
+    }
+
+    private int normalizedStep() {
+        return Math.max(1, step);
+    }
+
+    public Mode mode() {
+        return mode;
+    }
+
+    public String parameter() {
+        return parameter;
+    }
+
+    public int start() {
+        return start;
+    }
+
+    public int step() {
+        return step;
+    }
+
+    public String sizeParameter() {
+        return sizeParameter;
+    }
+
+    public static PagingStrategy from(String mode, String parameter, int start, int step, String sizeParameter) {
+        if (mode == null || mode.isBlank()) {
+            return disabled();
+        }
+        Mode parsed = Mode.valueOf(mode.trim().toUpperCase(Locale.ROOT));
+        return switch (parsed) {
+            case NONE -> disabled();
+            case QUERY -> query(parameter, start, step, sizeParameter);
+            case PATH_SUFFIX -> pathSuffix(start, step);
+            case OFFSET -> offset(parameter, start, step, sizeParameter);
+        };
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserField.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserField.java
@@ -1,0 +1,142 @@
+package com.vibe.jobs.crawler.domain;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+public class ParserField {
+
+    private final String name;
+    private final ParserFieldType type;
+    private final String selector;
+    private final String attribute;
+    private final String constant;
+    private final String format;
+    private final String delimiter;
+    private final boolean required;
+
+    public ParserField(String name,
+                       ParserFieldType type,
+                       String selector,
+                       String attribute,
+                       String constant,
+                       String format,
+                       String delimiter,
+                       boolean required) {
+        this.name = name == null ? "" : name.trim();
+        this.type = type == null ? ParserFieldType.TEXT : type;
+        this.selector = selector == null ? "" : selector.trim();
+        this.attribute = attribute == null ? "" : attribute.trim();
+        this.constant = constant == null ? "" : constant.trim();
+        this.format = format == null ? "" : format.trim();
+        this.delimiter = delimiter == null ? "," : delimiter;
+        this.required = required;
+    }
+
+    public static ParserField of(String name, ParserFieldType type, String selector) {
+        return new ParserField(name, type, selector, null, null, null, ",", false);
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public ParserFieldType type() {
+        return type;
+    }
+
+    public String selector() {
+        return selector;
+    }
+
+    public String attribute() {
+        return attribute;
+    }
+
+    public boolean required() {
+        return required;
+    }
+
+    public Object extract(Element element) {
+        if (element == null) {
+            return null;
+        }
+        return switch (type) {
+            case CONSTANT -> constant;
+            case HTML -> select(element).stream().findFirst().map(Element::html).orElse(null);
+            case ATTRIBUTE -> select(element).stream().findFirst()
+                    .map(el -> attribute.isBlank() ? el.text() : el.attr(attribute))
+                    .map(String::trim)
+                    .filter(value -> !value.isBlank())
+                    .orElse(null);
+            case LIST -> parseList(element);
+            case DATE -> parseDate(element);
+            case TEXT -> select(element).stream().findFirst()
+                    .map(Element::text)
+                    .map(String::trim)
+                    .filter(value -> !value.isBlank())
+                    .orElse(null);
+        };
+    }
+
+    private List<Element> select(Element element) {
+        if (selector.isBlank()) {
+            return Collections.singletonList(element);
+        }
+        Elements elements = element.select(selector);
+        if (elements == null || elements.isEmpty()) {
+            return List.of();
+        }
+        return elements.stream().toList();
+    }
+
+    private Object parseDate(Element element) {
+        String value = null;
+        if (selector.isBlank()) {
+            value = element.text();
+        } else {
+            value = element.select(selector).text();
+        }
+        value = value == null ? null : value.trim();
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (format.isBlank()) {
+            try {
+                return Instant.parse(value);
+            } catch (Exception ignored) {
+                return null;
+            }
+        }
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format, Locale.ROOT).withZone(ZoneOffset.UTC);
+            return formatter.parse(value, Instant::from);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Object parseList(Element element) {
+        String value = null;
+        if (selector.isBlank()) {
+            value = element.text();
+        } else {
+            value = element.select(selector).text();
+        }
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        String[] parts = value.split(delimiter == null || delimiter.isEmpty() ? "," : delimiter);
+        return Arrays.stream(parts)
+                .map(String::trim)
+                .filter(part -> !part.isBlank())
+                .toList();
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserFieldType.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserFieldType.java
@@ -1,0 +1,10 @@
+package com.vibe.jobs.crawler.domain;
+
+public enum ParserFieldType {
+    TEXT,
+    ATTRIBUTE,
+    HTML,
+    CONSTANT,
+    LIST,
+    DATE
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserProfile.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/domain/ParserProfile.java
@@ -1,0 +1,127 @@
+package com.vibe.jobs.crawler.domain;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.time.Instant;
+import java.util.*;
+
+public class ParserProfile {
+
+    private final String listSelector;
+    private final Map<String, ParserField> fields;
+    private final Set<String> tagFields;
+    private final String descriptionField;
+
+    private ParserProfile(String listSelector,
+                          Map<String, ParserField> fields,
+                          Set<String> tagFields,
+                          String descriptionField) {
+        this.listSelector = listSelector == null ? "" : listSelector.trim();
+        this.fields = fields == null ? Map.of() : Map.copyOf(fields);
+        this.tagFields = tagFields == null ? Set.of() : Set.copyOf(tagFields);
+        this.descriptionField = descriptionField == null ? "" : descriptionField.trim();
+    }
+
+    public static ParserProfile empty() {
+        return new ParserProfile("", Map.of(), Set.of(), "");
+    }
+
+    public static ParserProfile of(String listSelector,
+                                   Map<String, ParserField> fields,
+                                   Set<String> tagFields,
+                                   String descriptionField) {
+        return new ParserProfile(listSelector, fields, tagFields, descriptionField);
+    }
+
+    public String listSelector() {
+        return listSelector;
+    }
+
+    public Map<String, ParserField> fields() {
+        return fields;
+    }
+
+    public boolean isConfigured() {
+        return !listSelector.isBlank() && fields.containsKey("title");
+    }
+
+    public List<ParsedJob> parse(String html) {
+        if (html == null || html.isBlank()) {
+            return List.of();
+        }
+        Elements elements = org.jsoup.Jsoup.parse(html).select(listSelector);
+        if (elements == null || elements.isEmpty()) {
+            return List.of();
+        }
+        List<ParsedJob> result = new ArrayList<>();
+        for (Element element : elements) {
+            ParsedJob job = parse(element);
+            if (job != null) {
+                result.add(job);
+            }
+        }
+        return result;
+    }
+
+    public ParsedJob parse(Element element) {
+        if (element == null) {
+            return null;
+        }
+        Map<String, Object> values = new LinkedHashMap<>();
+        for (Map.Entry<String, ParserField> entry : fields.entrySet()) {
+            Object value = entry.getValue().extract(element);
+            if (value == null && entry.getValue().required()) {
+                return null;
+            }
+            if (value != null) {
+                values.put(entry.getKey(), value);
+            }
+        }
+        if (!values.containsKey("title")) {
+            return null;
+        }
+        String description = descriptionField.isBlank() ? element.html() : Objects.toString(values.get(descriptionField), element.html());
+        Set<String> tags = new LinkedHashSet<>();
+        for (String tagField : tagFields) {
+            Object raw = values.get(tagField);
+            if (raw instanceof Collection<?> collection) {
+                for (Object value : collection) {
+                    if (value != null) {
+                        String text = value.toString().trim();
+                        if (!text.isBlank()) {
+                            tags.add(text.toLowerCase(Locale.ROOT));
+                        }
+                    }
+                }
+            } else if (raw != null) {
+                String text = raw.toString().trim();
+                if (!text.isBlank()) {
+                    tags.add(text.toLowerCase(Locale.ROOT));
+                }
+            }
+        }
+        return new ParsedJob(
+                Objects.toString(values.getOrDefault("externalId", UUID.randomUUID().toString()), ""),
+                Objects.toString(values.get("title"), ""),
+                Objects.toString(values.getOrDefault("company", ""), ""),
+                Objects.toString(values.getOrDefault("location", ""), ""),
+                Objects.toString(values.getOrDefault("url", ""), ""),
+                Objects.toString(values.getOrDefault("level", ""), ""),
+                values.get("postedAt") instanceof Instant instant ? instant : null,
+                tags,
+                description
+        );
+    }
+
+    public record ParsedJob(String externalId,
+                             String title,
+                             String company,
+                             String location,
+                             String url,
+                             String level,
+                             Instant postedAt,
+                             Set<String> tags,
+                             String description) {
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/CrawlPageSnapshot.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/CrawlPageSnapshot.java
@@ -1,0 +1,13 @@
+package com.vibe.jobs.crawler.infrastructure.engine;
+
+import java.util.List;
+import java.util.Map;
+
+public record CrawlPageSnapshot(String pageContent,
+                                List<String> detailContents,
+                                Map<String, Object> metadata) {
+    public CrawlPageSnapshot {
+        detailContents = detailContents == null ? List.of() : List.copyOf(detailContents);
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/CrawlerExecutionEngine.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/CrawlerExecutionEngine.java
@@ -1,0 +1,8 @@
+package com.vibe.jobs.crawler.infrastructure.engine;
+
+import com.vibe.jobs.crawler.domain.CrawlPagination;
+import com.vibe.jobs.crawler.domain.CrawlSession;
+
+public interface CrawlerExecutionEngine {
+    CrawlPageSnapshot fetch(CrawlSession session, CrawlPagination pagination) throws Exception;
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/HttpCrawlerExecutionEngine.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/engine/HttpCrawlerExecutionEngine.java
@@ -1,0 +1,57 @@
+package com.vibe.jobs.crawler.infrastructure.engine;
+
+import com.vibe.jobs.crawler.domain.CrawlBlueprint;
+import com.vibe.jobs.crawler.domain.CrawlPagination;
+import com.vibe.jobs.crawler.domain.CrawlSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Component
+public class HttpCrawlerExecutionEngine implements CrawlerExecutionEngine {
+
+    private static final Logger log = LoggerFactory.getLogger(HttpCrawlerExecutionEngine.class);
+    private final WebClient.Builder webClientBuilder;
+
+    public HttpCrawlerExecutionEngine(WebClient.Builder webClientBuilder) {
+        this.webClientBuilder = webClientBuilder;
+    }
+
+    @Override
+    public CrawlPageSnapshot fetch(CrawlSession session, CrawlPagination pagination) {
+        CrawlBlueprint blueprint = session.blueprint();
+        String url = blueprint.resolveEntryUrl(session.context(), pagination);
+        if (url == null || url.isBlank()) {
+            return new CrawlPageSnapshot("", java.util.List.of(), Map.of("status", 400));
+        }
+        WebClient client = webClientBuilder
+                .baseUrl(url)
+                .defaultHeader(HttpHeaders.ACCEPT, MediaType.TEXT_HTML_VALUE)
+                .defaultHeader(HttpHeaders.USER_AGENT, randomUserAgent())
+                .build();
+
+        log.debug("Fetching crawl page {} for blueprint {}", pagination.page(), blueprint.code());
+        String body = client.get()
+                .retrieve()
+                .bodyToMono(String.class)
+                .block(Duration.ofSeconds(30));
+
+        return new CrawlPageSnapshot(body == null ? "" : body, java.util.List.of(), Map.of("url", url));
+    }
+
+    private String randomUserAgent() {
+        String[] agents = new String[]{
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Safari/537.36",
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15",
+                "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/124.0"
+        };
+        return agents[ThreadLocalRandom.current().nextInt(agents.length)];
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerBlueprintEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerBlueprintEntity.java
@@ -1,0 +1,75 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "crawler_blueprint")
+public class CrawlerBlueprintEntity {
+
+    @Id
+    @Column(length = 128)
+    private String code;
+
+    @Column(nullable = false, length = 256)
+    private String name;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column(name = "entry_url", length = 2048)
+    private String entryUrl;
+
+    @Column(name = "concurrency_limit")
+    private int concurrencyLimit;
+
+    @Lob
+    @Column(name = "config_json")
+    private String configJson;
+
+    @Column(name = "parser_template_code", length = 128)
+    private String parserTemplateCode;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getEntryUrl() {
+        return entryUrl;
+    }
+
+    public int getConcurrencyLimit() {
+        return concurrencyLimit;
+    }
+
+    public String getConfigJson() {
+        return configJson;
+    }
+
+    public String getParserTemplateCode() {
+        return parserTemplateCode;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerCacheEntryEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerCacheEntryEntity.java
@@ -1,0 +1,37 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "crawler_cache")
+public class CrawlerCacheEntryEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "blueprint_code", length = 128)
+    private String blueprintCode;
+
+    @Column(name = "cache_key", length = 256)
+    private String cacheKey;
+
+    @Lob
+    @Column(name = "response_blob")
+    private byte[] responseBlob;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    public CrawlerCacheEntryEntity() {
+    }
+
+    public CrawlerCacheEntryEntity(String blueprintCode, String cacheKey, byte[] responseBlob, Instant expiresAt) {
+        this.blueprintCode = blueprintCode;
+        this.cacheKey = cacheKey;
+        this.responseBlob = responseBlob;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerParserTemplateEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerParserTemplateEntity.java
@@ -1,0 +1,47 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "crawler_parser_template")
+public class CrawlerParserTemplateEntity {
+
+    @Id
+    @Column(length = 128)
+    private String code;
+
+    @Column(length = 256)
+    private String description;
+
+    @Lob
+    @Column(name = "config_json")
+    private String configJson;
+
+    @Column(name = "created_at")
+    private Instant createdAt;
+
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getConfigJson() {
+        return configJson;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerRunLogEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/CrawlerRunLogEntity.java
@@ -1,0 +1,74 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "crawler_run_log")
+public class CrawlerRunLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "run_id", length = 128, unique = true)
+    private String runId;
+
+    @Column(name = "blueprint_code", length = 128)
+    private String blueprintCode;
+
+    @Column(name = "data_source_code", length = 128)
+    private String dataSourceCode;
+
+    @Column(length = 128)
+    private String company;
+
+    @Column(name = "page_index")
+    private int pageIndex;
+
+    @Column(name = "job_count")
+    private int jobCount;
+
+    @Column(name = "duration_ms")
+    private long durationMs;
+
+    @Column(name = "success")
+    private boolean success;
+
+    @Column(name = "error", length = 1024)
+    private String error;
+
+    @Column(name = "started_at")
+    private Instant startedAt;
+
+    @Column(name = "completed_at")
+    private Instant completedAt;
+
+    public CrawlerRunLogEntity() {
+    }
+
+    public CrawlerRunLogEntity(String runId,
+                               String blueprintCode,
+                               String dataSourceCode,
+                               String company,
+                               int pageIndex,
+                               int jobCount,
+                               long durationMs,
+                               boolean success,
+                               String error,
+                               Instant startedAt,
+                               Instant completedAt) {
+        this.runId = runId;
+        this.blueprintCode = blueprintCode;
+        this.dataSourceCode = dataSourceCode;
+        this.company = company;
+        this.pageIndex = pageIndex;
+        this.jobCount = jobCount;
+        this.durationMs = durationMs;
+        this.success = success;
+        this.error = error;
+        this.startedAt = startedAt;
+        this.completedAt = completedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlRunRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlRunRepository.java
@@ -1,0 +1,35 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import com.vibe.jobs.crawler.domain.CrawlRun;
+import com.vibe.jobs.crawler.domain.CrawlRunRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class JpaCrawlRunRepository implements CrawlRunRepository {
+
+    private final SpringDataCrawlerRunLogRepository runLogRepository;
+
+    public JpaCrawlRunRepository(SpringDataCrawlerRunLogRepository runLogRepository) {
+        this.runLogRepository = runLogRepository;
+    }
+
+    @Override
+    public void save(CrawlRun run) {
+        if (run == null) {
+            return;
+        }
+        runLogRepository.save(new CrawlerRunLogEntity(
+                run.id(),
+                run.blueprintCode(),
+                run.dataSourceCode(),
+                run.company(),
+                run.pageIndex(),
+                run.jobCount(),
+                run.durationMs(),
+                run.success(),
+                run.error(),
+                run.startedAt(),
+                run.completedAt()
+        ));
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlerBlueprintRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlerBlueprintRepository.java
@@ -1,0 +1,209 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.jobs.crawler.domain.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.*;
+
+@Repository
+public class JpaCrawlerBlueprintRepository implements CrawlerBlueprintRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(JpaCrawlerBlueprintRepository.class);
+
+    private final SpringDataCrawlerBlueprintJpaRepository jpaRepository;
+    private final ObjectMapper objectMapper;
+    private final CrawlerParserTemplateRepository templateRepository;
+
+    public JpaCrawlerBlueprintRepository(SpringDataCrawlerBlueprintJpaRepository jpaRepository,
+                                         ObjectMapper objectMapper,
+                                         CrawlerParserTemplateRepository templateRepository) {
+        this.jpaRepository = jpaRepository;
+        this.objectMapper = objectMapper;
+        this.templateRepository = templateRepository;
+    }
+
+    @Override
+    public Optional<CrawlBlueprint> findByCode(String code) {
+        return jpaRepository.findById(code == null ? "" : code.trim())
+                .map(this::mapEntity);
+    }
+
+    @Override
+    public List<CrawlBlueprint> findAllEnabled() {
+        return jpaRepository.findAllByEnabledTrue().stream()
+                .map(this::mapEntity)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private CrawlBlueprint mapEntity(CrawlerBlueprintEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        BlueprintConfig config = readConfig(entity.getConfigJson());
+        ParserProfile parserProfile = resolveParser(entity, config);
+        PagingStrategy pagingStrategy = resolvePaging(config);
+        CrawlFlow flow = resolveFlow(config);
+        CrawlBlueprint.RateLimit rateLimit = resolveRateLimit(config);
+        Map<String, Object> metadata = config == null || config.metadata == null ? Map.of() : config.metadata;
+        String entryUrl = entity.getEntryUrl() == null || entity.getEntryUrl().isBlank()
+                ? (config == null ? "" : Optional.ofNullable(config.entryUrl).orElse(""))
+                : entity.getEntryUrl();
+        return new CrawlBlueprint(
+                entity.getCode(),
+                entity.getName(),
+                entity.isEnabled(),
+                entity.getConcurrencyLimit(),
+                entryUrl,
+                pagingStrategy,
+                flow,
+                parserProfile,
+                rateLimit,
+                metadata
+        );
+    }
+
+    private ParserProfile resolveParser(CrawlerBlueprintEntity entity, BlueprintConfig config) {
+        ParserProfile profileFromConfig = config == null ? ParserProfile.empty() : buildProfile(config.parser);
+        if (profileFromConfig != null && profileFromConfig.isConfigured()) {
+            return profileFromConfig;
+        }
+        if (entity.getParserTemplateCode() != null && !entity.getParserTemplateCode().isBlank()) {
+            return templateRepository.findByCode(entity.getParserTemplateCode())
+                    .orElse(ParserProfile.empty());
+        }
+        return profileFromConfig == null ? ParserProfile.empty() : profileFromConfig;
+    }
+
+    private PagingStrategy resolvePaging(BlueprintConfig config) {
+        if (config == null || config.paging == null) {
+            return PagingStrategy.disabled();
+        }
+        BlueprintConfig.Paging paging = config.paging;
+        String mode = paging.mode == null ? "NONE" : paging.mode;
+        int start = paging.start == null ? 1 : paging.start;
+        int step = paging.step == null ? 1 : paging.step;
+        String parameter = paging.parameter;
+        String sizeParameter = paging.sizeParameter;
+        return PagingStrategy.from(mode, parameter, start, step, sizeParameter);
+    }
+
+    private CrawlFlow resolveFlow(BlueprintConfig config) {
+        if (config == null || config.flow == null || config.flow.isEmpty()) {
+            return CrawlFlow.empty();
+        }
+        List<CrawlStep> steps = new ArrayList<>();
+        for (BlueprintConfig.FlowStep step : config.flow) {
+            CrawlStepType type = CrawlStepType.REQUEST;
+            if (step.type != null && !step.type.isBlank()) {
+                try {
+                    type = CrawlStepType.valueOf(step.type.trim().toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException ignored) {
+                }
+            }
+            steps.add(new CrawlStep(type, step.options == null ? Map.of() : step.options));
+        }
+        return CrawlFlow.of(steps);
+    }
+
+    private CrawlBlueprint.RateLimit resolveRateLimit(BlueprintConfig config) {
+        if (config == null || config.rateLimit == null) {
+            return CrawlBlueprint.RateLimit.unlimited();
+        }
+        int rpm = config.rateLimit.requestsPerMinute == null ? 0 : config.rateLimit.requestsPerMinute;
+        int burst = config.rateLimit.burst == null ? 1 : config.rateLimit.burst;
+        return CrawlBlueprint.RateLimit.of(rpm, burst);
+    }
+
+    private ParserProfile buildProfile(BlueprintConfig.Parser parser) {
+        if (parser == null) {
+            return ParserProfile.empty();
+        }
+        Map<String, ParserField> fields = new LinkedHashMap<>();
+        if (parser.fields != null) {
+            parser.fields.forEach((name, field) -> {
+                ParserFieldType type = ParserFieldType.TEXT;
+                if (field.type != null) {
+                    try {
+                        type = ParserFieldType.valueOf(field.type.trim().toUpperCase(Locale.ROOT));
+                    } catch (IllegalArgumentException ignored) {
+                    }
+                }
+                ParserField parserField = new ParserField(
+                        name,
+                        type,
+                        field.selector,
+                        field.attribute,
+                        field.constant,
+                        field.format,
+                        field.delimiter,
+                        Boolean.TRUE.equals(field.required)
+                );
+                fields.put(name, parserField);
+            });
+        }
+        Set<String> tagFields = parser.tagFields == null ? Set.of() : new LinkedHashSet<>(parser.tagFields);
+        String descriptionField = parser.descriptionField;
+        return ParserProfile.of(parser.listSelector, fields, tagFields, descriptionField);
+    }
+
+    private BlueprintConfig readConfig(String json) {
+        if (json == null || json.isBlank()) {
+            return new BlueprintConfig();
+        }
+        try {
+            return objectMapper.readValue(json, BlueprintConfig.class);
+        } catch (IOException e) {
+            log.warn("Failed to parse crawler blueprint config: {}", e.getMessage());
+            return new BlueprintConfig();
+        }
+    }
+
+    static class BlueprintConfig {
+        public String entryUrl;
+        public Paging paging;
+        public Parser parser;
+        public RateLimit rateLimit;
+        public Map<String, Object> metadata;
+        public List<FlowStep> flow;
+
+        static class Paging {
+            public String mode;
+            public String parameter;
+            public Integer start;
+            public Integer step;
+            public String sizeParameter;
+        }
+
+        static class Parser {
+            public String listSelector;
+            public Map<String, Field> fields;
+            public List<String> tagFields;
+            public String descriptionField;
+        }
+
+        static class Field {
+            public String type;
+            public String selector;
+            public String attribute;
+            public String constant;
+            public String format;
+            public String delimiter;
+            public Boolean required;
+        }
+
+        static class RateLimit {
+            public Integer requestsPerMinute;
+            public Integer burst;
+        }
+
+        static class FlowStep {
+            public String type;
+            public Map<String, Object> options;
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlerParserTemplateRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/JpaCrawlerParserTemplateRepository.java
@@ -1,0 +1,92 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.jobs.crawler.domain.CrawlerParserTemplateRepository;
+import com.vibe.jobs.crawler.domain.ParserField;
+import com.vibe.jobs.crawler.domain.ParserFieldType;
+import com.vibe.jobs.crawler.domain.ParserProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@Repository
+public class JpaCrawlerParserTemplateRepository implements CrawlerParserTemplateRepository {
+
+    private static final Logger log = LoggerFactory.getLogger(JpaCrawlerParserTemplateRepository.class);
+
+    private final SpringDataCrawlerParserTemplateJpaRepository jpaRepository;
+    private final ObjectMapper objectMapper;
+
+    public JpaCrawlerParserTemplateRepository(SpringDataCrawlerParserTemplateJpaRepository jpaRepository,
+                                              ObjectMapper objectMapper) {
+        this.jpaRepository = jpaRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Optional<ParserProfile> findByCode(String code) {
+        return jpaRepository.findById(code == null ? "" : code.trim())
+                .map(entity -> parseProfile(entity.getConfigJson()));
+    }
+
+    private ParserProfile parseProfile(String json) {
+        if (json == null || json.isBlank()) {
+            return ParserProfile.empty();
+        }
+        try {
+            ParserConfig config = objectMapper.readValue(json, ParserConfig.class);
+            Map<String, ParserField> fields = new LinkedHashMap<>();
+            if (config.fields != null) {
+                config.fields.forEach((name, field) -> {
+                    ParserFieldType type = ParserFieldType.TEXT;
+                    if (field.type != null) {
+                        try {
+                            type = ParserFieldType.valueOf(field.type.trim().toUpperCase(Locale.ROOT));
+                        } catch (IllegalArgumentException ignored) {
+                        }
+                    }
+                    fields.put(name, new ParserField(
+                            name,
+                            type,
+                            field.selector,
+                            field.attribute,
+                            field.constant,
+                            field.format,
+                            field.delimiter,
+                            Boolean.TRUE.equals(field.required)
+                    ));
+                });
+            }
+            Set<String> tagFields = config.tagFields == null ? Set.of() : new LinkedHashSet<>(config.tagFields);
+            return ParserProfile.of(config.listSelector, fields, tagFields, config.descriptionField);
+        } catch (IOException e) {
+            log.warn("Failed to parse crawler parser template: {}", e.getMessage());
+            return ParserProfile.empty();
+        }
+    }
+
+    static class ParserConfig {
+        public String listSelector;
+        public Map<String, Field> fields;
+        public Set<String> tagFields;
+        public String descriptionField;
+
+        static class Field {
+            public String type;
+            public String selector;
+            public String attribute;
+            public String constant;
+            public String format;
+            public String delimiter;
+            public Boolean required;
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerBlueprintJpaRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerBlueprintJpaRepository.java
@@ -1,0 +1,9 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringDataCrawlerBlueprintJpaRepository extends JpaRepository<CrawlerBlueprintEntity, String> {
+    List<CrawlerBlueprintEntity> findAllByEnabledTrue();
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerCacheRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerCacheRepository.java
@@ -1,0 +1,9 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataCrawlerCacheRepository extends JpaRepository<CrawlerCacheEntryEntity, Long> {
+    Optional<CrawlerCacheEntryEntity> findFirstByBlueprintCodeAndCacheKey(String blueprintCode, String cacheKey);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerParserTemplateJpaRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerParserTemplateJpaRepository.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataCrawlerParserTemplateJpaRepository extends JpaRepository<CrawlerParserTemplateEntity, String> {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerRunLogRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/jpa/SpringDataCrawlerRunLogRepository.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.crawler.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataCrawlerRunLogRepository extends JpaRepository<CrawlerRunLogEntity, Long> {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/CrawlerParserEngine.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/CrawlerParserEngine.java
@@ -1,0 +1,12 @@
+package com.vibe.jobs.crawler.infrastructure.parser;
+
+import com.vibe.jobs.crawler.domain.CrawlSession;
+import com.vibe.jobs.crawler.infrastructure.engine.CrawlPageSnapshot;
+
+import java.util.List;
+
+import com.vibe.jobs.crawler.domain.CrawlResult;
+
+public interface CrawlerParserEngine {
+    List<CrawlResult> parse(CrawlSession session, CrawlPageSnapshot snapshot);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/DefaultCrawlerParserEngine.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/DefaultCrawlerParserEngine.java
@@ -1,0 +1,71 @@
+package com.vibe.jobs.crawler.infrastructure.parser;
+
+import com.vibe.jobs.crawler.domain.CrawlContext;
+import com.vibe.jobs.crawler.domain.CrawlResult;
+import com.vibe.jobs.crawler.domain.CrawlSession;
+import com.vibe.jobs.crawler.domain.ParserProfile;
+import com.vibe.jobs.crawler.domain.ParserProfile.ParsedJob;
+import com.vibe.jobs.domain.Job;
+import com.vibe.jobs.sources.FetchedJob;
+import com.vibe.jobs.crawler.infrastructure.engine.CrawlPageSnapshot;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class DefaultCrawlerParserEngine implements CrawlerParserEngine {
+
+    @Override
+    public List<CrawlResult> parse(CrawlSession session, CrawlPageSnapshot snapshot) {
+        ParserProfile profile = session.blueprint().parserProfile();
+        List<ParsedJob> parsed = profile.parse(snapshot.pageContent());
+        List<CrawlResult> results = new ArrayList<>();
+        CrawlContext context = session.context();
+        for (ParsedJob job : parsed) {
+            if (job.title() == null || job.title().isBlank()) {
+                continue;
+            }
+            Job domainJob = Job.builder()
+                    .source(resolveSourceName(context))
+                    .externalId(job.externalId().isBlank() ? job.title() : job.externalId())
+                    .title(job.title())
+                    .company(resolveCompany(context, job))
+                    .location(job.location())
+                    .level(job.level())
+                    .postedAt(job.postedAt() == null ? Instant.now() : job.postedAt())
+                    .url(job.url())
+                    .tags(normalizeTags(job.tags()))
+                    .build();
+            results.add(new CrawlResult(new FetchedJob(domainJob, job.description()), job.description(), Map.of()));
+        }
+        return results;
+    }
+
+    private String resolveSourceName(CrawlContext context) {
+        if (context.sourceName() != null && !context.sourceName().isBlank()) {
+            return context.sourceName();
+        }
+        return context.dataSourceCode().isBlank() ? "crawler" : "crawler:" + context.dataSourceCode();
+    }
+
+    private String resolveCompany(CrawlContext context, ParsedJob parsed) {
+        if (parsed.company() != null && !parsed.company().isBlank()) {
+            return parsed.company();
+        }
+        return context.company().isBlank() ? parsed.company() : context.company();
+    }
+
+    private Set<String> normalizeTags(Set<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Set.of();
+        }
+        return tags.stream()
+                .map(tag -> tag == null ? "" : tag.trim().toLowerCase())
+                .filter(tag -> !tag.isBlank())
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
@@ -135,6 +135,13 @@ public class SourceRegistry {
         if (!context.company().isBlank()) {
             merged.putIfAbsent("company", context.company());
         }
+        if (source.getCode() != null) {
+            merged.putIfAbsent("__sourceCode", source.getCode());
+            merged.putIfAbsent("__sourceName", "crawler:" + source.getCode());
+        }
+        if (!context.company().isBlank()) {
+            merged.put("__company", context.company());
+        }
         merged.replaceAll((k, v) -> applyPlaceholders(v, context));
         merged.values().removeIf(value -> value == null || value.isBlank());
         return merged;

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/CrawlerSourceClient.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/CrawlerSourceClient.java
@@ -1,0 +1,36 @@
+package com.vibe.jobs.sources;
+
+import com.vibe.jobs.crawler.application.CrawlerOrchestrator;
+import com.vibe.jobs.crawler.domain.CrawlContext;
+
+import java.util.List;
+import java.util.Map;
+
+public class CrawlerSourceClient implements SourceClient {
+
+    private final String blueprintCode;
+    private final CrawlerOrchestrator orchestrator;
+    private final CrawlContext context;
+
+    public CrawlerSourceClient(String blueprintCode,
+                               CrawlerOrchestrator orchestrator,
+                               String dataSourceCode,
+                               String company,
+                               String sourceName,
+                               String entryUrlOverride,
+                               Map<String, String> options) {
+        this.blueprintCode = blueprintCode;
+        this.orchestrator = orchestrator;
+        this.context = new CrawlContext(dataSourceCode, company, sourceName, entryUrlOverride, options);
+    }
+
+    @Override
+    public String sourceName() {
+        return context.sourceName().isBlank() ? "crawler:" + blueprintCode : context.sourceName();
+    }
+
+    @Override
+    public List<FetchedJob> fetchPage(int page, int size) {
+        return orchestrator.fetchJobs(blueprintCode, context, page, size);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/SourceClientFactory.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/SourceClientFactory.java
@@ -1,5 +1,6 @@
 package com.vibe.jobs.sources;
 
+import com.vibe.jobs.crawler.application.CrawlerOrchestrator;
 import org.springframework.stereotype.Component;
 
 import java.util.Locale;
@@ -7,6 +8,12 @@ import java.util.Map;
 
 @Component
 public class SourceClientFactory {
+
+    private final CrawlerOrchestrator crawlerOrchestrator;
+
+    public SourceClientFactory(CrawlerOrchestrator crawlerOrchestrator) {
+        this.crawlerOrchestrator = crawlerOrchestrator;
+    }
 
     public SourceClient create(String type, Map<String, String> options) {
         if (type == null || type.isBlank()) {
@@ -46,6 +53,15 @@ public class SourceClientFactory {
                     require(opts, "company"),
                     opts.get("baseUrl")
             );
+            case "crawler" -> new CrawlerSourceClient(
+                    resolveBlueprint(opts),
+                    crawlerOrchestrator,
+                    opts.getOrDefault("__sourceCode", ""),
+                    opts.getOrDefault("__company", ""),
+                    opts.getOrDefault("sourceName", opts.getOrDefault("__sourceName", "")),
+                    opts.getOrDefault("entryUrl", ""),
+                    opts
+            );
             default -> throw new IllegalArgumentException("Unsupported source type: " + type);
         };
     }
@@ -56,5 +72,13 @@ public class SourceClientFactory {
             throw new IllegalArgumentException("Missing required option '" + key + "'");
         }
         return value;
+    }
+
+    private String resolveBlueprint(Map<String, String> options) {
+        String blueprint = options.getOrDefault("blueprintCode", options.getOrDefault("crawlerBlueprintCode", ""));
+        if (blueprint == null || blueprint.isBlank()) {
+            throw new IllegalArgumentException("Missing required option 'blueprintCode'");
+        }
+        return blueprint;
     }
 }

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V7__crawler_tables.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V7__crawler_tables.sql
@@ -1,0 +1,45 @@
+CREATE TABLE IF NOT EXISTS crawler_blueprint (
+    code VARCHAR(128) PRIMARY KEY,
+    name VARCHAR(256) NOT NULL,
+    enabled TINYINT(1) NOT NULL DEFAULT 1,
+    entry_url VARCHAR(2048),
+    concurrency_limit INT NOT NULL DEFAULT 1,
+    config_json LONGTEXT,
+    parser_template_code VARCHAR(128),
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS crawler_parser_template (
+    code VARCHAR(128) PRIMARY KEY,
+    description VARCHAR(256),
+    config_json LONGTEXT,
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS crawler_run_log (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    run_id VARCHAR(128) UNIQUE,
+    blueprint_code VARCHAR(128),
+    data_source_code VARCHAR(128),
+    company VARCHAR(128),
+    page_index INT,
+    job_count INT,
+    duration_ms BIGINT,
+    success TINYINT(1) DEFAULT 1,
+    error VARCHAR(1024),
+    started_at TIMESTAMP NULL,
+    completed_at TIMESTAMP NULL,
+    INDEX idx_run_log_blueprint (blueprint_code),
+    INDEX idx_run_log_started (started_at)
+);
+
+CREATE TABLE IF NOT EXISTS crawler_cache (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    blueprint_code VARCHAR(128) NOT NULL,
+    cache_key VARCHAR(256) NOT NULL,
+    response_blob LONGBLOB,
+    expires_at TIMESTAMP NULL,
+    UNIQUE KEY uk_crawler_cache (blueprint_code, cache_key)
+);


### PR DESCRIPTION
## Summary
- introduce a crawler bounded context with blueprints, pagination, parser profiles, orchestration and metrics logging
- persist crawler metadata through new JPA entities/repositories and a Flyway migration for blueprint, parser template, run log and cache tables
- wire the crawler source client into the existing source factory/registry and document how to configure crawler data sources

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download spring-boot-starter-parent from Maven Central due to HTTP 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dd563865c08328acc06fb3587b479a