### PR TITLE
Sync legacy ingestion configuration with database entries

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
@@ -17,6 +17,8 @@ public interface JobDataSourceRepository {
     void saveAll(Collection<JobDataSource> sources);
 
     boolean existsAny();
-    
+
     boolean existsByCode(String code);
+
+    Optional<JobDataSource> findByCode(String code);
 }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
@@ -70,6 +70,11 @@ public class JpaJobDataSourceRepository implements JobDataSourceRepository {
         return delegate.existsByCode(code);
     }
 
+    @Override
+    public Optional<JobDataSource> findByCode(String code) {
+        return delegate.findByCode(code).map(this::toDomain);
+    }
+
     private JobDataSource toDomain(JobDataSourceEntity entity) {
         List<JobDataSource.DataSourceCompany> companies = entity.getCompanies().stream()
                 .map(company -> new JobDataSource.DataSourceCompany(

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/SpringDataJobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/SpringDataJobDataSourceRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SpringDataJobDataSourceRepository extends JpaRepository<JobDataSourceEntity, Long> {
 
@@ -15,6 +16,9 @@ public interface SpringDataJobDataSourceRepository extends JpaRepository<JobData
     @Override
     @EntityGraph(attributePaths = {"companies", "categories"})
     List<JobDataSourceEntity> findAll();
-    
+
     boolean existsByCode(String code);
+
+    @EntityGraph(attributePaths = {"companies", "categories"})
+    Optional<JobDataSourceEntity> findByCode(String code);
 }

--- a/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/datasource/application/migration/LegacyIngestionConfigurationImporterTest.java
+++ b/vibe-jobs-aggregator/src/test/java/com/vibe/jobs/datasource/application/migration/LegacyIngestionConfigurationImporterTest.java
@@ -1,0 +1,135 @@
+package com.vibe.jobs.datasource.application.migration;
+
+import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.datasource.application.DataSourceCommandService;
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import com.vibe.jobs.datasource.domain.JobDataSourceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LegacyIngestionConfigurationImporterTest {
+
+    @Mock
+    private DataSourceCommandService commandService;
+
+    @Mock
+    private JobDataSourceRepository repository;
+
+    @Captor
+    private ArgumentCaptor<List<JobDataSource>> dataSourceListCaptor;
+
+    private IngestionProperties properties;
+
+    private LegacyIngestionConfigurationImporter importer;
+
+    @BeforeEach
+    void setUp() {
+        properties = new IngestionProperties();
+        importer = new LegacyIngestionConfigurationImporter(properties, commandService, repository);
+    }
+
+    @Test
+    void migratesAllSourcesWhenDatabaseIsEmpty() {
+        properties.setCompanies(List.of("Acme"));
+        IngestionProperties.Source ashby = new IngestionProperties.Source();
+        ashby.setId("ashby");
+        ashby.setType("ashby");
+        ashby.setRequireOverride(false);
+        ashby.setOptions(Map.of("token", "abc"));
+        properties.setSources(List.of(ashby));
+
+        when(repository.existsAny()).thenReturn(false);
+        when(repository.findByCode("ashby")).thenReturn(Optional.empty());
+
+        importer.migrateIfNecessary();
+
+        verify(commandService).saveAll(dataSourceListCaptor.capture());
+        assertThat(dataSourceListCaptor.getValue()).hasSize(1);
+        JobDataSource saved = dataSourceListCaptor.getValue().get(0);
+        assertThat(saved.getCode()).isEqualTo("ashby");
+        assertThat(saved.getCompanies()).hasSize(1);
+        assertThat(saved.getCompanies().get(0).reference()).isEqualTo("acme");
+    }
+
+    @Test
+    void updatesExistingSourceWhenConfigurationChanges() {
+        properties.setCompanies(List.of("Acme"));
+        IngestionProperties.Source ashby = new IngestionProperties.Source();
+        ashby.setId("ashby");
+        ashby.setType("ashby");
+        ashby.setRequireOverride(false);
+        ashby.setOptions(Map.of("token", "updated"));
+        properties.setSources(List.of(ashby));
+
+        JobDataSource existing = new JobDataSource(
+                10L,
+                "ashby",
+                "ashby",
+                true,
+                true,
+                false,
+                JobDataSource.Flow.UNLIMITED,
+                Map.of("token", "old"),
+                List.of(),
+                List.of(new JobDataSource.DataSourceCompany(1L, "acme", "Acme", "acme", true, Map.of(), Map.of()))
+        );
+
+        when(repository.existsAny()).thenReturn(true);
+        when(repository.findByCode("ashby")).thenReturn(Optional.of(existing));
+
+        importer.migrateIfNecessary();
+
+        ArgumentCaptor<JobDataSource> updatedCaptor = ArgumentCaptor.forClass(JobDataSource.class);
+        verify(commandService).save(updatedCaptor.capture());
+        JobDataSource updated = updatedCaptor.getValue();
+        assertThat(updated.getId()).isEqualTo(10L);
+        assertThat(updated.getBaseOptions()).containsEntry("token", "updated");
+    }
+
+    @Test
+    void skipsUpdateWhenExistingConfigurationMatches() {
+        properties.setCompanies(List.of("Acme"));
+        IngestionProperties.Source ashby = new IngestionProperties.Source();
+        ashby.setId("ashby");
+        ashby.setType("ashby");
+        ashby.setRequireOverride(false);
+        ashby.setOptions(Map.of("token", "abc"));
+        properties.setSources(List.of(ashby));
+
+        JobDataSource existing = new JobDataSource(
+                10L,
+                "ashby",
+                "ashby",
+                true,
+                true,
+                false,
+                JobDataSource.Flow.UNLIMITED,
+                Map.of("token", "abc"),
+                List.of(),
+                List.of(new JobDataSource.DataSourceCompany(1L, "acme", "Acme", "acme", true, Map.of(), Map.of()))
+        );
+
+        when(repository.existsAny()).thenReturn(true);
+        when(repository.findByCode("ashby")).thenReturn(Optional.of(existing));
+
+        importer.migrateIfNecessary();
+
+        verify(commandService, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(commandService, never()).saveAll(org.mockito.ArgumentMatchers.anyList());
+    }
+}


### PR DESCRIPTION
## Summary
- update the legacy ingestion migration to insert missing sources and update existing ones from application.yml
- expose a repository lookup by code so the migration can detect existing records
- add unit tests covering empty database, updates, and no-op scenarios

## Testing
- mvn -q test *(fails: cannot resolve parent POM because Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df5e2a869c83289e6130cf4739e811