### PR TITLE
Add admin schema bootstrap script for manual database setup

### DIFF
--- a/setup-database.sh
+++ b/setup-database.sh
@@ -25,7 +25,19 @@ echo "User: $DB_USER"
 echo
 
 echo ">> Setting up database schema..."
-mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" < vibe-jobs-aggregator/scripts/manual-db-setup.sql
+SCHEMA_SCRIPTS=(
+    "vibe-jobs-aggregator/scripts/simple-db-setup.sql"
+    "vibe-jobs-aggregator/scripts/2024-07-15_admin_tables.sql"
+)
+
+for schema_script in "${SCHEMA_SCRIPTS[@]}"; do
+    if [[ ! -f "$schema_script" ]]; then
+        echo "Error: missing schema script $schema_script" >&2
+        exit 1
+    fi
+    echo "   -> running ${schema_script##*/}"
+    mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" < "$schema_script"
+done
 
 echo
 echo ">> Verifying setup..."

--- a/vibe-jobs-aggregator/docs/production-rds-checklist.md
+++ b/vibe-jobs-aggregator/docs/production-rds-checklist.md
@@ -39,6 +39,7 @@ local docker settings so the backend connects to the managed RDS endpoint.
 - [ ] Trigger a backend deployment (`./deploy.sh` or an ECS force deployment).
 - [ ] Watch the backend logs; Flyway should emit `Successfully applied 2 migrations`.
 - [ ] Verify tables with `mysql -h <endpoint> -u vibejobs -p -e 'SHOW TABLES IN vibejobs;'`.
+- ℹ️ If you bootstrap the database manually (before letting Flyway run), execute `setup-database.sh`. It now runs both `scripts/simple-db-setup.sql` and `scripts/2024-07-15_admin_tables.sql` so the admin tables and whitelist seed are created alongside the ingestion schema.
 
 ## 4. Post-deployment verification
 - [ ] Hit `https://<your-domain>/api/actuator/health` and confirm status `UP`.

--- a/vibe-jobs-aggregator/scripts/2024-07-15_admin_tables.sql
+++ b/vibe-jobs-aggregator/scripts/2024-07-15_admin_tables.sql
@@ -1,0 +1,40 @@
+-- Manual bootstrap for admin tables previously managed by Flyway V8
+-- Run alongside simple-db-setup.sql when seeding a new environment without Flyway
+
+CREATE TABLE IF NOT EXISTS ingestion_settings (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    setting_key VARCHAR(128) NOT NULL,
+    setting_value LONGTEXT,
+    description VARCHAR(255),
+    updated_by VARCHAR(320),
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_ingestion_settings_key (setting_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS admin_change_log (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    actor_email VARCHAR(320) NOT NULL,
+    change_type VARCHAR(128) NOT NULL,
+    entity_type VARCHAR(128) NOT NULL,
+    entity_id VARCHAR(128),
+    details LONGTEXT,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    KEY idx_admin_change_log_created_at (created_at),
+    KEY idx_admin_change_log_actor (actor_email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS admin_allowed_email (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    email VARCHAR(320) NOT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_admin_allowed_email_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO admin_allowed_email (email) VALUES
+    ('admin@elainejobs.com'),
+    ('ops@elainejobs.com');


### PR DESCRIPTION
## Summary
- add a standalone admin schema bootstrap SQL script with ingestion settings and whitelist seed
- update setup-database.sh to run the new script alongside the existing simple bootstrap
- document the manual bootstrap flow so production checklist references the new script location

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df94a18d9c83288ff4fbb176591dba