### PR TITLE
feat: add admin console for ingestion and data sources

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminAccessService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminAccessService.java
@@ -1,0 +1,21 @@
+package com.vibe.jobs.admin.application;
+
+import com.vibe.jobs.admin.infrastructure.jpa.SpringDataAdminAllowedEmailRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AdminAccessService {
+
+    private final SpringDataAdminAllowedEmailRepository repository;
+
+    public AdminAccessService(SpringDataAdminAllowedEmailRepository repository) {
+        this.repository = repository;
+    }
+
+    public boolean isAllowed(String email) {
+        if (email == null || email.isBlank()) {
+            return false;
+        }
+        return repository.existsById(email.trim().toLowerCase());
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminChangeLogService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminChangeLogService.java
@@ -1,0 +1,60 @@
+package com.vibe.jobs.admin.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.jobs.admin.infrastructure.jpa.AdminChangeLogEntity;
+import com.vibe.jobs.admin.infrastructure.jpa.SpringDataAdminChangeLogRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+public class AdminChangeLogService {
+
+    private static final Logger log = LoggerFactory.getLogger(AdminChangeLogService.class);
+
+    private final SpringDataAdminChangeLogRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public AdminChangeLogService(SpringDataAdminChangeLogRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    public void record(String actorEmail,
+                       String action,
+                       String resourceType,
+                       String resourceId,
+                       Object diff) {
+        if (actorEmail == null || actorEmail.isBlank()) {
+            return;
+        }
+        AdminChangeLogEntity entity = new AdminChangeLogEntity();
+        entity.setActorEmail(actorEmail);
+        entity.setAction(action == null ? "UNKNOWN" : action);
+        entity.setResourceType(resourceType == null ? "UNKNOWN" : resourceType);
+        entity.setResourceId(resourceId);
+        entity.setDiffJson(serialize(diff));
+        repository.save(entity);
+    }
+
+    private String serialize(Object diff) {
+        if (diff == null) {
+            return null;
+        }
+        if (diff instanceof String str) {
+            return str;
+        }
+        if (diff instanceof Map<?, ?> map && map.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(diff);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to serialize admin diff: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminDataSourceService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/AdminDataSourceService.java
@@ -1,0 +1,57 @@
+package com.vibe.jobs.admin.application;
+
+import com.vibe.jobs.admin.domain.event.DataSourceConfigurationChangedEvent;
+import com.vibe.jobs.datasource.application.DataSourceCommandService;
+import com.vibe.jobs.datasource.application.DataSourceQueryService;
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class AdminDataSourceService {
+
+    private final DataSourceQueryService queryService;
+    private final DataSourceCommandService commandService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public AdminDataSourceService(DataSourceQueryService queryService,
+                                  DataSourceCommandService commandService,
+                                  ApplicationEventPublisher eventPublisher) {
+        this.queryService = queryService;
+        this.commandService = commandService;
+        this.eventPublisher = eventPublisher;
+    }
+
+    public List<JobDataSource> listAll() {
+        return queryService.fetchAll();
+    }
+
+    public JobDataSource getById(Long id) {
+        return queryService.getById(id);
+    }
+
+    public JobDataSource create(JobDataSource source) {
+        JobDataSource saved = commandService.save(source.normalized());
+        publishChange(saved.getCode());
+        return saved;
+    }
+
+    public JobDataSource update(Long id, JobDataSource source) {
+        JobDataSource withId = source.withId(id).normalized();
+        JobDataSource saved = commandService.save(withId);
+        publishChange(saved.getCode());
+        return saved;
+    }
+
+    public void delete(Long id) {
+        JobDataSource existing = queryService.getById(id);
+        commandService.delete(id);
+        publishChange(existing.getCode());
+    }
+
+    private void publishChange(String code) {
+        eventPublisher.publishEvent(new DataSourceConfigurationChangedEvent(code));
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/IngestionSettingsService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/application/IngestionSettingsService.java
@@ -1,0 +1,145 @@
+package com.vibe.jobs.admin.application;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+import com.vibe.jobs.admin.domain.event.IngestionSettingsUpdatedEvent;
+import com.vibe.jobs.admin.infrastructure.jpa.IngestionSettingsEntity;
+import com.vibe.jobs.admin.infrastructure.jpa.SpringDataIngestionSettingsRepository;
+import com.vibe.jobs.config.IngestionProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+public class IngestionSettingsService {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestionSettingsService.class);
+    private static final long SETTINGS_ID = 1L;
+
+    private final SpringDataIngestionSettingsRepository repository;
+    private final ObjectMapper objectMapper;
+    private final IngestionProperties ingestionProperties;
+    private final ApplicationEventPublisher eventPublisher;
+    private final AtomicReference<IngestionSettingsSnapshot> current;
+
+    public IngestionSettingsService(SpringDataIngestionSettingsRepository repository,
+                                    ObjectMapper objectMapper,
+                                    IngestionProperties ingestionProperties,
+                                    ApplicationEventPublisher eventPublisher) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+        this.ingestionProperties = ingestionProperties;
+        this.eventPublisher = eventPublisher;
+        this.current = new AtomicReference<>();
+    }
+
+    @PostConstruct
+    public void onApplicationStarted() {
+        initializeIfNeeded();
+    }
+
+    @Transactional(readOnly = true)
+    public IngestionSettingsSnapshot current() {
+        IngestionSettingsSnapshot snapshot = current.get();
+        if (snapshot != null) {
+            return snapshot;
+        }
+        return loadOrInitialize();
+    }
+
+    @Transactional
+    public synchronized IngestionSettingsSnapshot initializeIfNeeded() {
+        IngestionSettingsSnapshot snapshot = current.get();
+        if (snapshot != null) {
+            return snapshot;
+        }
+        snapshot = loadOrInitialize();
+        current.set(snapshot);
+        snapshot.applyTo(ingestionProperties);
+        return snapshot;
+    }
+
+    @Transactional
+    public IngestionSettingsSnapshot update(IngestionSettingsSnapshot snapshot) {
+        IngestionSettingsSnapshot normalized = new IngestionSettingsSnapshot(
+                snapshot.fixedDelayMs(),
+                snapshot.initialDelayMs(),
+                snapshot.pageSize(),
+                snapshot.mode(),
+                snapshot.companies(),
+                snapshot.recentDays(),
+                snapshot.concurrency(),
+                snapshot.companyOverrides(),
+                snapshot.locationFilter(),
+                snapshot.roleFilter(),
+                Instant.now()
+        );
+        persist(normalized);
+        normalized.applyTo(ingestionProperties);
+        current.set(normalized);
+        eventPublisher.publishEvent(new IngestionSettingsUpdatedEvent(normalized));
+        return normalized;
+    }
+
+    private IngestionSettingsSnapshot loadOrInitialize() {
+        IngestionSettingsSnapshot snapshot = repository.findById(SETTINGS_ID)
+                .map(this::toSnapshot)
+                .map(snapshot -> {
+                    snapshot.applyTo(ingestionProperties);
+                    return snapshot;
+                })
+                .orElseGet(() -> {
+                    IngestionSettingsSnapshot snapshot = IngestionSettingsSnapshot.fromProperties(ingestionProperties, Instant.now());
+                    persist(snapshot);
+                    return snapshot;
+                });
+        current.set(snapshot);
+        return snapshot;
+    }
+
+    private void persist(IngestionSettingsSnapshot snapshot) {
+        String json = serialize(snapshot);
+        IngestionSettingsEntity entity = repository.findById(SETTINGS_ID)
+                .orElse(new IngestionSettingsEntity());
+        entity.setId(SETTINGS_ID);
+        entity.setSettingsJson(json);
+        repository.save(entity);
+    }
+
+    private IngestionSettingsSnapshot toSnapshot(IngestionSettingsEntity entity) {
+        try {
+            IngestionSettingsSnapshot snapshot = objectMapper.readValue(entity.getSettingsJson(), IngestionSettingsSnapshot.class);
+            return new IngestionSettingsSnapshot(
+                    snapshot.fixedDelayMs(),
+                    snapshot.initialDelayMs(),
+                    snapshot.pageSize(),
+                    snapshot.mode(),
+                    snapshot.companies(),
+                    snapshot.recentDays(),
+                    snapshot.concurrency(),
+                    snapshot.companyOverrides(),
+                    snapshot.locationFilter(),
+                    snapshot.roleFilter(),
+                    entity.getUpdatedAt()
+            );
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse ingestion settings JSON, falling back to defaults: {}", e.getMessage());
+            return IngestionSettingsSnapshot.fromProperties(ingestionProperties, Instant.now());
+        }
+    }
+
+    private String serialize(IngestionSettingsSnapshot snapshot) {
+        try {
+            return objectMapper.writeValueAsString(snapshot);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Unable to serialize ingestion settings", e);
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/AdminPrincipal.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/AdminPrincipal.java
@@ -1,0 +1,4 @@
+package com.vibe.jobs.admin.domain;
+
+public record AdminPrincipal(String email) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/IngestionSettingsSnapshot.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/IngestionSettingsSnapshot.java
@@ -1,0 +1,276 @@
+package com.vibe.jobs.admin.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vibe.jobs.config.IngestionProperties;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+public final class IngestionSettingsSnapshot {
+
+    private final long fixedDelayMs;
+    private final long initialDelayMs;
+    private final int pageSize;
+    private final IngestionProperties.Mode mode;
+    private final List<String> companies;
+    private final int recentDays;
+    private final int concurrency;
+    private final Map<String, IngestionProperties.CompanyOverride> companyOverrides;
+    private final IngestionProperties.LocationFilter locationFilter;
+    private final IngestionProperties.RoleFilter roleFilter;
+    private final Instant updatedAt;
+
+    @JsonCreator
+    public IngestionSettingsSnapshot(
+            @JsonProperty("fixedDelayMs") long fixedDelayMs,
+            @JsonProperty("initialDelayMs") long initialDelayMs,
+            @JsonProperty("pageSize") int pageSize,
+            @JsonProperty("mode") IngestionProperties.Mode mode,
+            @JsonProperty("companies") List<String> companies,
+            @JsonProperty("recentDays") int recentDays,
+            @JsonProperty("concurrency") int concurrency,
+            @JsonProperty("companyOverrides") Map<String, IngestionProperties.CompanyOverride> companyOverrides,
+            @JsonProperty("locationFilter") IngestionProperties.LocationFilter locationFilter,
+            @JsonProperty("roleFilter") IngestionProperties.RoleFilter roleFilter,
+            @JsonProperty("updatedAt") Instant updatedAt) {
+        this.fixedDelayMs = fixedDelayMs <= 0 ? 3_600_000L : fixedDelayMs;
+        this.initialDelayMs = Math.max(0, initialDelayMs);
+        this.pageSize = Math.max(1, pageSize);
+        this.mode = mode == null ? IngestionProperties.Mode.RECENT : mode;
+        this.companies = sanitizeCompanies(companies);
+        this.recentDays = Math.max(1, recentDays);
+        this.concurrency = Math.max(1, concurrency);
+        this.companyOverrides = sanitizeOverrides(companyOverrides);
+        this.locationFilter = cloneLocationFilter(locationFilter);
+        this.roleFilter = cloneRoleFilter(roleFilter);
+        this.updatedAt = updatedAt == null ? Instant.now() : updatedAt;
+    }
+
+    public static IngestionSettingsSnapshot fromProperties(IngestionProperties properties, Instant updatedAt) {
+        Objects.requireNonNull(properties, "properties");
+        return new IngestionSettingsSnapshot(
+                properties.getFixedDelayMs(),
+                properties.getInitialDelayMs(),
+                properties.getPageSize(),
+                properties.getMode(),
+                properties.getCompanies(),
+                properties.getRecentDays(),
+                properties.getConcurrency(),
+                properties.getCompanyOverrides(),
+                properties.getLocationFilter(),
+                properties.getRoleFilter(),
+                updatedAt
+        );
+    }
+
+    public void applyTo(IngestionProperties properties) {
+        Objects.requireNonNull(properties, "properties");
+        properties.setFixedDelayMs(fixedDelayMs);
+        properties.setInitialDelayMs(initialDelayMs);
+        properties.setPageSize(pageSize);
+        properties.setMode(mode);
+        properties.setCompanies(new ArrayList<>(companies));
+        properties.setRecentDays(recentDays);
+        properties.setConcurrency(concurrency);
+        properties.setCompanyOverrides(companyOverrides);
+        properties.setLocationFilter(cloneLocationFilter(locationFilter));
+        properties.setRoleFilter(cloneRoleFilter(roleFilter));
+    }
+
+    public long fixedDelayMs() {
+        return fixedDelayMs;
+    }
+
+    public long initialDelayMs() {
+        return initialDelayMs;
+    }
+
+    public int pageSize() {
+        return pageSize;
+    }
+
+    public IngestionProperties.Mode mode() {
+        return mode;
+    }
+
+    public List<String> companies() {
+        return companies;
+    }
+
+    public int recentDays() {
+        return recentDays;
+    }
+
+    public int concurrency() {
+        return concurrency;
+    }
+
+    public Map<String, IngestionProperties.CompanyOverride> companyOverrides() {
+        return companyOverrides;
+    }
+
+    public IngestionProperties.LocationFilter locationFilter() {
+        return cloneLocationFilter(locationFilter);
+    }
+
+    public IngestionProperties.RoleFilter roleFilter() {
+        return cloneRoleFilter(roleFilter);
+    }
+
+    public Instant updatedAt() {
+        return updatedAt;
+    }
+
+    private static List<String> sanitizeCompanies(List<String> raw) {
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
+        List<String> sanitized = new ArrayList<>();
+        for (String value : raw) {
+            if (value == null) {
+                continue;
+            }
+            String trimmed = value.trim();
+            if (!trimmed.isEmpty()) {
+                sanitized.add(trimmed);
+            }
+        }
+        return List.copyOf(sanitized);
+    }
+
+    private static Map<String, IngestionProperties.CompanyOverride> sanitizeOverrides(
+            Map<String, IngestionProperties.CompanyOverride> overrides) {
+        if (overrides == null || overrides.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, IngestionProperties.CompanyOverride> sanitized = new LinkedHashMap<>();
+        overrides.forEach((key, value) -> {
+            if (key == null || key.isBlank() || value == null) {
+                return;
+            }
+            sanitized.put(key.trim().toLowerCase(Locale.ROOT), value.normalized());
+        });
+        return Map.copyOf(sanitized);
+    }
+
+    private static IngestionProperties.LocationFilter cloneLocationFilter(IngestionProperties.LocationFilter source) {
+        IngestionProperties.LocationFilter clone = new IngestionProperties.LocationFilter();
+        if (source == null) {
+            return clone;
+        }
+        clone.setEnabled(source.isEnabled());
+        clone.setIncludeCountries(new ArrayList<>(source.getIncludeCountries()));
+        clone.setIncludeRegions(new ArrayList<>(source.getIncludeRegions()));
+        clone.setIncludeCities(new ArrayList<>(source.getIncludeCities()));
+        clone.setExcludeCountries(new ArrayList<>(source.getExcludeCountries()));
+        clone.setExcludeRegions(new ArrayList<>(source.getExcludeRegions()));
+        clone.setExcludeCities(new ArrayList<>(source.getExcludeCities()));
+        clone.setIncludeKeywords(new ArrayList<>(source.getIncludeKeywords()));
+        clone.setExcludeKeywords(new ArrayList<>(source.getExcludeKeywords()));
+        return clone;
+    }
+
+    private static IngestionProperties.RoleFilter cloneRoleFilter(IngestionProperties.RoleFilter source) {
+        IngestionProperties.RoleFilter clone = new IngestionProperties.RoleFilter();
+        if (source == null) {
+            return clone;
+        }
+        clone.setEnabled(source.isEnabled());
+        clone.setAllowKeywords(new ArrayList<>(source.getAllowKeywords()));
+        clone.setBlockKeywords(new ArrayList<>(source.getBlockKeywords()));
+        clone.setAllowLevels(new ArrayList<>(source.getAllowLevels()));
+        clone.setBlockLevels(new ArrayList<>(source.getBlockLevels()));
+        clone.setAllowCategories(new ArrayList<>(source.getAllowCategories()));
+        clone.setBlockCategories(new ArrayList<>(source.getBlockCategories()));
+        return clone;
+    }
+}
+mkdir -p vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa
+cat <<'EOF' > vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/IngestionSettingsEntity.java
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "ingestion_settings")
+public class IngestionSettingsEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "settings_json", nullable = false, columnDefinition = "TEXT")
+    private String settingsJson;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public IngestionSettingsEntity() {
+    }
+
+    public IngestionSettingsEntity(Long id, String settingsJson) {
+        this.id = id;
+        this.settingsJson = settingsJson;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSettingsJson() {
+        return settingsJson;
+    }
+
+    public void setSettingsJson(String settingsJson) {
+        this.settingsJson = settingsJson;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/event/DataSourceConfigurationChangedEvent.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/event/DataSourceConfigurationChangedEvent.java
@@ -1,0 +1,4 @@
+package com.vibe.jobs.admin.domain.event;
+
+public record DataSourceConfigurationChangedEvent(String sourceCode) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/event/IngestionSettingsUpdatedEvent.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/domain/event/IngestionSettingsUpdatedEvent.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.admin.domain.event;
+
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+
+public record IngestionSettingsUpdatedEvent(IngestionSettingsSnapshot snapshot) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/AdminAllowedEmailEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/AdminAllowedEmailEntity.java
@@ -1,0 +1,30 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "admin_allowed_email")
+public class AdminAllowedEmailEntity {
+
+    @Id
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    public AdminAllowedEmailEntity() {
+    }
+
+    public AdminAllowedEmailEntity(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/AdminChangeLogEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/AdminChangeLogEntity.java
@@ -1,0 +1,97 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "admin_change_log")
+public class AdminChangeLogEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "actor_email", nullable = false)
+    private String actorEmail;
+
+    @Column(name = "action", nullable = false)
+    private String action;
+
+    @Column(name = "resource_type", nullable = false)
+    private String resourceType;
+
+    @Column(name = "resource_id")
+    private String resourceId;
+
+    @Column(name = "diff_json", columnDefinition = "TEXT")
+    private String diffJson;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = Instant.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getActorEmail() {
+        return actorEmail;
+    }
+
+    public void setActorEmail(String actorEmail) {
+        this.actorEmail = actorEmail;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(String action) {
+        this.action = action;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public String getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(String resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getDiffJson() {
+        return diffJson;
+    }
+
+    public void setDiffJson(String diffJson) {
+        this.diffJson = diffJson;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/IngestionSettingsEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/IngestionSettingsEntity.java
@@ -1,0 +1,81 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "ingestion_settings")
+public class IngestionSettingsEntity {
+
+    @Id
+    private Long id;
+
+    @Column(name = "settings_json", nullable = false, columnDefinition = "TEXT")
+    private String settingsJson;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    public IngestionSettingsEntity() {
+    }
+
+    public IngestionSettingsEntity(Long id, String settingsJson) {
+        this.id = id;
+        this.settingsJson = settingsJson;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        Instant now = Instant.now();
+        if (createdAt == null) {
+            createdAt = now;
+        }
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSettingsJson() {
+        return settingsJson;
+    }
+
+    public void setSettingsJson(String settingsJson) {
+        this.settingsJson = settingsJson;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataAdminAllowedEmailRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataAdminAllowedEmailRepository.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataAdminAllowedEmailRepository extends JpaRepository<AdminAllowedEmailEntity, String> {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataAdminChangeLogRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataAdminChangeLogRepository.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataAdminChangeLogRepository extends JpaRepository<AdminChangeLogEntity, Long> {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataIngestionSettingsRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/infrastructure/jpa/SpringDataIngestionSettingsRepository.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.admin.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SpringDataIngestionSettingsRepository extends JpaRepository<IngestionSettingsEntity, Long> {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminAuthInterceptor.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminAuthInterceptor.java
@@ -1,0 +1,81 @@
+package com.vibe.jobs.admin.web;
+
+import com.vibe.jobs.admin.application.AdminAccessService;
+import com.vibe.jobs.admin.domain.AdminPrincipal;
+import com.vibe.jobs.auth.application.EmailAuthService;
+import com.vibe.jobs.auth.application.EmailAuthService.AuthenticatedUser;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class AdminAuthInterceptor implements HandlerInterceptor {
+
+    static final String ADMIN_PRINCIPAL_ATTR = AdminPrincipal.class.getName();
+
+    private final EmailAuthService emailAuthService;
+    private final AdminAccessService accessService;
+
+    public AdminAuthInterceptor(EmailAuthService emailAuthService, AdminAccessService accessService) {
+        this.emailAuthService = emailAuthService;
+        this.accessService = accessService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request,
+                             HttpServletResponse response,
+                             Object handler) throws IOException {
+        String token = resolveToken(request);
+        if (token == null) {
+            reject(response, HttpStatus.UNAUTHORIZED, "MISSING_SESSION");
+            return false;
+        }
+        Optional<AuthenticatedUser> resolved = emailAuthService.resolveSession(token);
+        if (resolved.isEmpty()) {
+            reject(response, HttpStatus.UNAUTHORIZED, "INVALID_SESSION");
+            return false;
+        }
+        String email = resolved.get().email();
+        if (!accessService.isAllowed(email)) {
+            reject(response, HttpStatus.FORBIDDEN, "NOT_ALLOWED");
+            return false;
+        }
+        request.setAttribute(ADMIN_PRINCIPAL_ATTR, new AdminPrincipal(email));
+        return true;
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("X-Session-Token");
+        if (header != null && !header.isBlank()) {
+            return header.trim();
+        }
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String bearer = authHeader.substring(7).trim();
+            if (!bearer.isEmpty()) {
+                return bearer;
+            }
+        }
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie != null && "vj_session".equals(cookie.getName())) {
+                    String value = cookie.getValue();
+                    if (value != null && !value.isBlank()) {
+                        return value.trim();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void reject(HttpServletResponse response, HttpStatus status, String code) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.getWriter().write("{\"code\":\"" + code + "\"}");
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminDataSourceController.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminDataSourceController.java
@@ -1,0 +1,109 @@
+package com.vibe.jobs.admin.web;
+
+import com.vibe.jobs.admin.application.AdminChangeLogService;
+import com.vibe.jobs.admin.application.AdminDataSourceService;
+import com.vibe.jobs.admin.domain.AdminPrincipal;
+import com.vibe.jobs.admin.web.dto.DataSourceRequest;
+import com.vibe.jobs.admin.web.dto.DataSourceResponse;
+import com.vibe.jobs.datasource.domain.JobDataSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "/admin/data-sources", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminDataSourceController {
+
+    private final AdminDataSourceService dataSourceService;
+    private final AdminChangeLogService changeLogService;
+
+    public AdminDataSourceController(AdminDataSourceService dataSourceService,
+                                     AdminChangeLogService changeLogService) {
+        this.dataSourceService = dataSourceService;
+        this.changeLogService = changeLogService;
+    }
+
+    @GetMapping
+    public List<DataSourceResponse> list() {
+        return dataSourceService.listAll().stream()
+                .map(DataSourceResponse::fromDomain)
+                .toList();
+    }
+
+    @GetMapping("/{id}")
+    public DataSourceResponse get(@PathVariable Long id) {
+        try {
+            JobDataSource source = dataSourceService.getById(id);
+            return DataSourceResponse.fromDomain(source);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+    }
+
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public DataSourceResponse create(@RequestBody DataSourceRequest request,
+                                     AdminPrincipal principal) {
+        JobDataSource created = dataSourceService.create(request.toDomain(null));
+        changeLogService.record(
+                principal != null ? principal.email() : null,
+                "CREATE",
+                "DATA_SOURCE",
+                created.getId() == null ? created.getCode() : created.getId().toString(),
+                Map.of("after", created)
+        );
+        return DataSourceResponse.fromDomain(created);
+    }
+
+    @PutMapping(path = "/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public DataSourceResponse update(@PathVariable Long id,
+                                     @RequestBody DataSourceRequest request,
+                                     AdminPrincipal principal) {
+        JobDataSource before;
+        try {
+            before = dataSourceService.getById(id);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+        JobDataSource updated = dataSourceService.update(id, request.toDomain(id));
+        changeLogService.record(
+                principal != null ? principal.email() : null,
+                "UPDATE",
+                "DATA_SOURCE",
+                id.toString(),
+                Map.of("before", before, "after", updated)
+        );
+        return DataSourceResponse.fromDomain(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id, AdminPrincipal principal) {
+        JobDataSource before;
+        try {
+            before = dataSourceService.getById(id);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        }
+        dataSourceService.delete(id);
+        changeLogService.record(
+                principal != null ? principal.email() : null,
+                "DELETE",
+                "DATA_SOURCE",
+                id.toString(),
+                Map.of("before", before)
+        );
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminIngestionSettingsController.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminIngestionSettingsController.java
@@ -1,0 +1,51 @@
+package com.vibe.jobs.admin.web;
+
+import com.vibe.jobs.admin.application.AdminChangeLogService;
+import com.vibe.jobs.admin.application.IngestionSettingsService;
+import com.vibe.jobs.admin.domain.AdminPrincipal;
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+import com.vibe.jobs.admin.web.dto.IngestionSettingsRequest;
+import com.vibe.jobs.admin.web.dto.IngestionSettingsResponse;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping(path = "/admin/ingestion-settings", produces = MediaType.APPLICATION_JSON_VALUE)
+public class AdminIngestionSettingsController {
+
+    private final IngestionSettingsService ingestionSettingsService;
+    private final AdminChangeLogService changeLogService;
+
+    public AdminIngestionSettingsController(IngestionSettingsService ingestionSettingsService,
+                                            AdminChangeLogService changeLogService) {
+        this.ingestionSettingsService = ingestionSettingsService;
+        this.changeLogService = changeLogService;
+    }
+
+    @GetMapping
+    public IngestionSettingsResponse getCurrent() {
+        IngestionSettingsSnapshot snapshot = ingestionSettingsService.current();
+        return IngestionSettingsResponse.fromSnapshot(snapshot);
+    }
+
+    @PutMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    public IngestionSettingsResponse update(@RequestBody IngestionSettingsRequest request,
+                                            AdminPrincipal principal) {
+        IngestionSettingsSnapshot before = ingestionSettingsService.current();
+        IngestionSettingsSnapshot updated = ingestionSettingsService.update(request.toSnapshot());
+        changeLogService.record(
+                principal != null ? principal.email() : null,
+                "UPDATE",
+                "INGESTION_SETTINGS",
+                "global",
+                Map.of("before", before, "after", updated)
+        );
+        return IngestionSettingsResponse.fromSnapshot(updated);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminPrincipalArgumentResolver.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminPrincipalArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.vibe.jobs.admin.web;
+
+import com.vibe.jobs.admin.domain.AdminPrincipal;
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.Nullable;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class AdminPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return AdminPrincipal.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  @Nullable ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  @Nullable org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (request == null) {
+            return null;
+        }
+        Object attribute = request.getAttribute(AdminAuthInterceptor.ADMIN_PRINCIPAL_ATTR);
+        if (attribute instanceof AdminPrincipal principal) {
+            return principal;
+        }
+        return null;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminWebMvcConfigurer.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/AdminWebMvcConfigurer.java
@@ -1,0 +1,33 @@
+package com.vibe.jobs.admin.web;
+
+import com.vibe.jobs.admin.application.AdminAccessService;
+import com.vibe.jobs.auth.application.EmailAuthService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class AdminWebMvcConfigurer implements WebMvcConfigurer {
+
+    private final EmailAuthService emailAuthService;
+    private final AdminAccessService accessService;
+
+    public AdminWebMvcConfigurer(EmailAuthService emailAuthService, AdminAccessService accessService) {
+        this.emailAuthService = emailAuthService;
+        this.accessService = accessService;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AdminAuthInterceptor(emailAuthService, accessService))
+                .addPathPatterns("/admin/**");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new AdminPrincipalArgumentResolver());
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/DataSourceRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/DataSourceRequest.java
@@ -1,0 +1,96 @@
+package com.vibe.jobs.admin.web.dto;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public record DataSourceRequest(
+        String code,
+        String type,
+        boolean enabled,
+        boolean runOnStartup,
+        boolean requireOverride,
+        String flow,
+        Map<String, String> baseOptions,
+        List<CategoryRequest> categories,
+        List<CompanyRequest> companies
+) {
+    public JobDataSource toDomain(Long id) {
+        JobDataSource.Flow resolvedFlow;
+        try {
+            resolvedFlow = flow == null ? JobDataSource.Flow.UNLIMITED : JobDataSource.Flow.valueOf(flow.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            resolvedFlow = JobDataSource.Flow.UNLIMITED;
+        }
+        Map<String, String> options = baseOptions == null ? Map.of() : new LinkedHashMap<>(baseOptions);
+        List<JobDataSource.CategoryQuotaDefinition> quotaDefinitions = new ArrayList<>();
+        if (categories != null) {
+            for (CategoryRequest category : categories) {
+                quotaDefinitions.add(category.toDomain());
+            }
+        }
+        List<JobDataSource.DataSourceCompany> companyList = new ArrayList<>();
+        if (companies != null) {
+            for (CompanyRequest company : companies) {
+                companyList.add(company.toDomain());
+            }
+        }
+        return new JobDataSource(
+                id,
+                code,
+                type,
+                enabled,
+                runOnStartup,
+                requireOverride,
+                resolvedFlow,
+                options,
+                quotaDefinitions,
+                companyList
+        );
+    }
+
+    public record CategoryRequest(
+            String name,
+            int limit,
+            List<String> tags,
+            Map<String, List<String>> facets
+    ) {
+        public JobDataSource.CategoryQuotaDefinition toDomain() {
+            List<String> normalizedTags = tags == null ? List.of() : new ArrayList<>(tags);
+            Map<String, List<String>> normalizedFacets = new LinkedHashMap<>();
+            if (facets != null) {
+                facets.forEach((key, values) -> {
+                    if (key == null) {
+                        return;
+                    }
+                    normalizedFacets.put(key, values == null ? List.of() : new ArrayList<>(values));
+                });
+            }
+            return new JobDataSource.CategoryQuotaDefinition(
+                    name,
+                    limit,
+                    normalizedTags,
+                    normalizedFacets
+            );
+        }
+    }
+
+    public record CompanyRequest(
+            Long id,
+            String reference,
+            String displayName,
+            String slug,
+            boolean enabled,
+            Map<String, String> placeholderOverrides,
+            Map<String, String> overrideOptions
+    ) {
+        public JobDataSource.DataSourceCompany toDomain() {
+            Map<String, String> placeholders = placeholderOverrides == null ? Map.of() : new LinkedHashMap<>(placeholderOverrides);
+            Map<String, String> overrides = overrideOptions == null ? Map.of() : new LinkedHashMap<>(overrideOptions);
+            return new JobDataSource.DataSourceCompany(id, reference, displayName, slug, enabled, placeholders, overrides);
+        }
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/DataSourceResponse.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/DataSourceResponse.java
@@ -1,0 +1,34 @@
+package com.vibe.jobs.admin.web.dto;
+
+import com.vibe.jobs.datasource.domain.JobDataSource;
+
+import java.util.List;
+import java.util.Map;
+
+public record DataSourceResponse(
+        Long id,
+        String code,
+        String type,
+        boolean enabled,
+        boolean runOnStartup,
+        boolean requireOverride,
+        JobDataSource.Flow flow,
+        Map<String, String> baseOptions,
+        List<JobDataSource.CategoryQuotaDefinition> categories,
+        List<JobDataSource.DataSourceCompany> companies
+) {
+    public static DataSourceResponse fromDomain(JobDataSource source) {
+        return new DataSourceResponse(
+                source.getId(),
+                source.getCode(),
+                source.getType(),
+                source.isEnabled(),
+                source.isRunOnStartup(),
+                source.isRequireOverride(),
+                source.getFlow(),
+                source.getBaseOptions(),
+                source.getCategories(),
+                source.getCompanies()
+        );
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/IngestionSettingsRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/IngestionSettingsRequest.java
@@ -1,0 +1,43 @@
+package com.vibe.jobs.admin.web.dto;
+
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+import com.vibe.jobs.config.IngestionProperties;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record IngestionSettingsRequest(
+        long fixedDelayMs,
+        long initialDelayMs,
+        int pageSize,
+        String mode,
+        List<String> companies,
+        int recentDays,
+        int concurrency,
+        IngestionProperties.LocationFilter locationFilter,
+        IngestionProperties.RoleFilter roleFilter,
+        Map<String, IngestionProperties.CompanyOverride> companyOverrides
+) {
+    public IngestionSettingsSnapshot toSnapshot() {
+        IngestionProperties.Mode resolvedMode;
+        try {
+            resolvedMode = mode == null ? IngestionProperties.Mode.RECENT : IngestionProperties.Mode.valueOf(mode.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            resolvedMode = IngestionProperties.Mode.RECENT;
+        }
+        return new IngestionSettingsSnapshot(
+                fixedDelayMs,
+                initialDelayMs,
+                pageSize,
+                resolvedMode,
+                companies,
+                recentDays,
+                concurrency,
+                companyOverrides,
+                locationFilter,
+                roleFilter,
+                Instant.now()
+        );
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/IngestionSettingsResponse.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/admin/web/dto/IngestionSettingsResponse.java
@@ -1,0 +1,38 @@
+package com.vibe.jobs.admin.web.dto;
+
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+import com.vibe.jobs.config.IngestionProperties;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record IngestionSettingsResponse(
+        long fixedDelayMs,
+        long initialDelayMs,
+        int pageSize,
+        IngestionProperties.Mode mode,
+        List<String> companies,
+        int recentDays,
+        int concurrency,
+        Map<String, IngestionProperties.CompanyOverride> companyOverrides,
+        IngestionProperties.LocationFilter locationFilter,
+        IngestionProperties.RoleFilter roleFilter,
+        Instant updatedAt
+) {
+    public static IngestionSettingsResponse fromSnapshot(IngestionSettingsSnapshot snapshot) {
+        return new IngestionSettingsResponse(
+                snapshot.fixedDelayMs(),
+                snapshot.initialDelayMs(),
+                snapshot.pageSize(),
+                snapshot.mode(),
+                snapshot.companies(),
+                snapshot.recentDays(),
+                snapshot.concurrency(),
+                snapshot.companyOverrides(),
+                snapshot.locationFilter(),
+                snapshot.roleFilter(),
+                snapshot.updatedAt()
+        );
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceCommandService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceCommandService.java
@@ -22,4 +22,8 @@ public class DataSourceCommandService {
     public void saveAll(Collection<JobDataSource> sources) {
         repository.saveAll(sources);
     }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
 }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceQueryService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/application/DataSourceQueryService.java
@@ -22,6 +22,15 @@ public class DataSourceQueryService {
         return repository.findAllEnabled();
     }
 
+    public List<JobDataSource> fetchAll() {
+        return repository.findAll();
+    }
+
+    public JobDataSource getById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Data source not found: " + id));
+    }
+
     public List<JobDataSource> fetchStartupSources() {
         return repository.findAllEnabled().stream()
                 .filter(JobDataSource::isRunOnStartup)

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/domain/JobDataSourceRepository.java
@@ -17,4 +17,6 @@ public interface JobDataSourceRepository {
     void saveAll(Collection<JobDataSource> sources);
 
     boolean existsAny();
+
+    void deleteById(Long id);
 }

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/datasource/infrastructure/jpa/JpaJobDataSourceRepository.java
@@ -65,6 +65,11 @@ public class JpaJobDataSourceRepository implements JobDataSourceRepository {
         return delegate.count() > 0;
     }
 
+    @Override
+    public void deleteById(Long id) {
+        delegate.deleteById(id);
+    }
+
     private JobDataSource toDomain(JobDataSourceEntity entity) {
         List<JobDataSource.DataSourceCompany> companies = entity.getCompanies().stream()
                 .map(company -> new JobDataSource.DataSourceCompany(

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/CareersApiStartupRunner.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/CareersApiStartupRunner.java
@@ -27,7 +27,7 @@ public class CareersApiStartupRunner implements ApplicationRunner {
     private final RoleFilterService roleFilterService;
     private final JobService jobService;
     private final JobDetailService jobDetailService;
-    private final ExecutorService executor;
+    private final IngestionExecutorManager executorManager;
 
     public CareersApiStartupRunner(SourceRegistry sourceRegistry,
                                    IngestionProperties ingestionProperties,
@@ -36,7 +36,7 @@ public class CareersApiStartupRunner implements ApplicationRunner {
                                    RoleFilterService roleFilterService,
                                    JobService jobService,
                                    JobDetailService jobDetailService,
-                                   ExecutorService executor) {
+                                   IngestionExecutorManager executorManager) {
         this.sourceRegistry = sourceRegistry;
         this.ingestionProperties = ingestionProperties;
         this.jobFilter = jobFilter;
@@ -44,7 +44,7 @@ public class CareersApiStartupRunner implements ApplicationRunner {
         this.roleFilterService = roleFilterService;
         this.jobService = jobService;
         this.jobDetailService = jobDetailService;
-        this.executor = executor;
+        this.executorManager = executorManager;
     }
 
     @Override
@@ -70,6 +70,7 @@ public class CareersApiStartupRunner implements ApplicationRunner {
             }
         }
 
+        ExecutorService executor = executorManager.getExecutor();
         CompletableFuture<?>[] tasks = unlimited.stream()
                 .map(source -> CompletableFuture.runAsync(() -> fetchOnce(source, pageSize), executor))
                 .toArray(CompletableFuture[]::new);

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionExecutorManager.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionExecutorManager.java
@@ -1,0 +1,77 @@
+package com.vibe.jobs.ingestion;
+
+import com.vibe.jobs.admin.application.IngestionSettingsService;
+import com.vibe.jobs.admin.domain.IngestionSettingsSnapshot;
+import com.vibe.jobs.admin.domain.event.IngestionSettingsUpdatedEvent;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component
+public class IngestionExecutorManager {
+
+    private static final Logger log = LoggerFactory.getLogger(IngestionExecutorManager.class);
+
+    private final ThreadPoolExecutor executor;
+
+    public IngestionExecutorManager(IngestionSettingsService settingsService) {
+        IngestionSettingsSnapshot snapshot = settingsService.initializeIfNeeded();
+        this.executor = createExecutor(snapshot.concurrency());
+    }
+
+    public ExecutorService getExecutor() {
+        return executor;
+    }
+
+    @EventListener
+    public void handleSettingsUpdated(IngestionSettingsUpdatedEvent event) {
+        if (event == null || event.snapshot() == null) {
+            return;
+        }
+        int concurrency = Math.max(1, event.snapshot().concurrency());
+        if (executor.getCorePoolSize() != concurrency) {
+            log.info("Adjust ingestion executor concurrency from {} to {}", executor.getCorePoolSize(), concurrency);
+            executor.setCorePoolSize(concurrency);
+            executor.setMaximumPoolSize(concurrency);
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    private ThreadPoolExecutor createExecutor(int concurrency) {
+        int threads = Math.max(1, concurrency);
+        ThreadFactory factory = new ThreadFactory() {
+            private final AtomicInteger counter = new AtomicInteger();
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName("ingestion-worker-" + counter.incrementAndGet());
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        ThreadPoolExecutor pool = new ThreadPoolExecutor(
+                threads,
+                threads,
+                60L,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(),
+                factory
+        );
+        pool.allowCoreThreadTimeOut(false);
+        return pool;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionSchedulingConfig.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionSchedulingConfig.java
@@ -1,0 +1,20 @@
+package com.vibe.jobs.ingestion;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class IngestionSchedulingConfig {
+
+    @Bean
+    public TaskScheduler ingestionTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        scheduler.setThreadNamePrefix("ingestion-scheduler-");
+        scheduler.setRemoveOnCancelPolicy(true);
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/SourceRegistry.java
@@ -10,6 +10,8 @@ import com.vibe.jobs.sources.SourceClient;
 import com.vibe.jobs.sources.SourceClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.vibe.jobs.admin.domain.event.DataSourceConfigurationChangedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -59,6 +61,20 @@ public class SourceRegistry {
             }
         }
         return resolved;
+    }
+
+    @EventListener
+    public void onDataSourceChanged(DataSourceConfigurationChangedEvent event) {
+        if (event == null) {
+            return;
+        }
+        String code = event.sourceCode();
+        if (code == null || code.isBlank()) {
+            clientCache.clear();
+            return;
+        }
+        String normalized = code.trim().toLowerCase(Locale.ROOT) + "::";
+        clientCache.keySet().removeIf(key -> key.toLowerCase(Locale.ROOT).startsWith(normalized));
     }
 
     private List<ConfiguredSource> resolveSingleInstance(JobDataSource source) {

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V8__create_admin_tables.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V8__create_admin_tables.sql
@@ -1,0 +1,22 @@
+CREATE TABLE ingestion_settings (
+    id BIGINT PRIMARY KEY,
+    settings_json TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_change_log (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    actor_email VARCHAR(255) NOT NULL,
+    action VARCHAR(64) NOT NULL,
+    resource_type VARCHAR(64) NOT NULL,
+    resource_id VARCHAR(128),
+    diff_json TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE admin_allowed_email (
+    email VARCHAR(255) PRIMARY KEY
+);
+
+INSERT INTO admin_allowed_email(email) VALUES ('975022570yp@gmail.com');

--- a/vibe-jobs-view/app/(admin)/admin/data-sources/page.tsx
+++ b/vibe-jobs-view/app/(admin)/admin/data-sources/page.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+
+interface CategoryQuotaDefinition {
+  name: string;
+  limit: number;
+  tags: string[];
+  facets: Record<string, string[]>;
+}
+
+interface DataSourceCompany {
+  id: number | null;
+  reference: string;
+  displayName: string;
+  slug: string;
+  enabled: boolean;
+  placeholderOverrides: Record<string, string>;
+  overrideOptions: Record<string, string>;
+}
+
+interface DataSourceResponse {
+  id: number;
+  code: string;
+  type: string;
+  enabled: boolean;
+  runOnStartup: boolean;
+  requireOverride: boolean;
+  flow: 'LIMITED' | 'UNLIMITED';
+  baseOptions: Record<string, string>;
+  categories: CategoryQuotaDefinition[];
+  companies: DataSourceCompany[];
+}
+
+async function fetchDataSources(): Promise<DataSourceResponse[]> {
+  const res = await fetch('/api/admin/data-sources', { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('无法获取数据源列表');
+  }
+  return res.json();
+}
+
+export default function DataSourcesPage() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, error } = useQuery({ queryKey: ['admin', 'data-sources'], queryFn: fetchDataSources });
+  const [selectedId, setSelectedId] = useState<number | 'new' | null>(null);
+  const [form, setForm] = useState({
+    code: '',
+    type: '',
+    enabled: true,
+    runOnStartup: false,
+    requireOverride: false,
+    flow: 'UNLIMITED' as 'LIMITED' | 'UNLIMITED',
+    baseOptionsJson: '{}',
+    categoriesJson: '[]',
+    companiesJson: '[]',
+  });
+  const [message, setMessage] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const selectedSource = useMemo(() => {
+    if (!data) return null;
+    if (selectedId === null || selectedId === 'new') return null;
+    return data.find((item) => item.id === selectedId) ?? null;
+  }, [data, selectedId]);
+
+  useEffect(() => {
+    if (selectedSource) {
+      setForm({
+        code: selectedSource.code,
+        type: selectedSource.type,
+        enabled: selectedSource.enabled,
+        runOnStartup: selectedSource.runOnStartup,
+        requireOverride: selectedSource.requireOverride,
+        flow: selectedSource.flow,
+        baseOptionsJson: JSON.stringify(selectedSource.baseOptions ?? {}, null, 2),
+        categoriesJson: JSON.stringify(selectedSource.categories ?? [], null, 2),
+        companiesJson: JSON.stringify(selectedSource.companies ?? [], null, 2),
+      });
+      setMessage(null);
+      setErrorMsg(null);
+    } else if (selectedId === 'new') {
+      setForm({
+        code: '',
+        type: '',
+        enabled: true,
+        runOnStartup: false,
+        requireOverride: false,
+        flow: 'UNLIMITED',
+        baseOptionsJson: '{}',
+        categoriesJson: '[]',
+        companiesJson: '[]',
+      });
+      setMessage(null);
+      setErrorMsg(null);
+    }
+  }, [selectedId, selectedSource]);
+
+  const saveMutation = useMutation({
+    mutationFn: async (payload: Record<string, unknown>) => {
+      const isNew = selectedId === 'new';
+      const url = isNew ? '/api/admin/data-sources' : `/api/admin/data-sources/${selectedId}`;
+      const method = isNew ? 'POST' : 'PUT';
+      const res = await fetch(url, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || '保存失败');
+      }
+      return res.json();
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'data-sources'] });
+      setMessage('数据源已保存');
+      setErrorMsg(null);
+      setSelectedId(null);
+    },
+    onError: (err: unknown) => {
+      setMessage(null);
+      setErrorMsg(err instanceof Error ? err.message : '保存失败');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (id: number) => {
+      const res = await fetch(`/api/admin/data-sources/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || '删除失败');
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'data-sources'] });
+      setSelectedId(null);
+      setMessage('数据源已删除');
+      setErrorMsg(null);
+    },
+    onError: (err: unknown) => {
+      setMessage(null);
+      setErrorMsg(err instanceof Error ? err.message : '删除失败');
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      const baseOptions = form.baseOptionsJson.trim() ? JSON.parse(form.baseOptionsJson) : {};
+      const categories = form.categoriesJson.trim() ? JSON.parse(form.categoriesJson) : [];
+      const companies = form.companiesJson.trim() ? JSON.parse(form.companiesJson) : [];
+      if (!form.code) {
+        throw new Error('Code 不能为空');
+      }
+      if (!form.type) {
+        throw new Error('Type 不能为空');
+      }
+      const payload = {
+        code: form.code,
+        type: form.type,
+        enabled: form.enabled,
+        runOnStartup: form.runOnStartup,
+        requireOverride: form.requireOverride,
+        flow: form.flow,
+        baseOptions,
+        categories,
+        companies,
+      };
+      saveMutation.mutate(payload);
+    } catch (err) {
+      setMessage(null);
+      setErrorMsg(err instanceof Error ? err.message : '无法解析 JSON');
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-white/80">加载中...</p>;
+  }
+
+  if (isError || !data) {
+    return <p className="text-red-300">{(error as Error)?.message ?? '加载失败'}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-white">数据源管理</h2>
+          <p className="text-sm text-white/70">支持动态增删改，保存后缓存立即刷新。</p>
+        </div>
+        <button
+          onClick={() => setSelectedId('new')}
+          className="rounded-md bg-white/10 px-3 py-2 text-sm font-medium text-white hover:bg-white/20"
+        >
+          新建数据源
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
+        <aside className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-4">
+          {data.map((source) => (
+            <button
+              key={source.id}
+              onClick={() => setSelectedId(source.id)}
+              className={`w-full rounded-lg border px-3 py-2 text-left text-sm transition ${
+                selectedId === source.id
+                  ? 'border-white/40 bg-white/15 text-white'
+                  : 'border-white/10 bg-transparent text-white/70 hover:border-white/30 hover:text-white'
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{source.code}</span>
+                <span className={`text-xs ${source.enabled ? 'text-emerald-300' : 'text-rose-300'}`}>
+                  {source.enabled ? '启用' : '停用'}
+                </span>
+              </div>
+              <p className="text-xs text-white/60">{source.type}</p>
+            </button>
+          ))}
+          {data.length === 0 && <p className="text-sm text-white/60">暂无数据源</p>}
+        </aside>
+
+        <section className="rounded-xl border border-white/10 bg-white/5 p-4">
+          {selectedId === null && <p className="text-sm text-white/70">请选择左侧数据源，或点击“新建数据源”。</p>}
+          {selectedId !== null && (
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="flex flex-col space-y-1 text-sm text-white/80">
+                  <span>Code</span>
+                  <input
+                    value={form.code}
+                    onChange={(e) => setForm((prev) => ({ ...prev, code: e.target.value }))}
+                    className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+                    required
+                  />
+                </label>
+                <label className="flex flex-col space-y-1 text-sm text-white/80">
+                  <span>Type</span>
+                  <input
+                    value={form.type}
+                    onChange={(e) => setForm((prev) => ({ ...prev, type: e.target.value }))}
+                    className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+                    required
+                  />
+                </label>
+                <label className="flex items-center space-x-2 text-sm text-white/80">
+                  <input
+                    type="checkbox"
+                    checked={form.enabled}
+                    onChange={(e) => setForm((prev) => ({ ...prev, enabled: e.target.checked }))}
+                    className="h-4 w-4 rounded border-white/20 bg-white/10"
+                  />
+                  <span>启用</span>
+                </label>
+                <label className="flex items-center space-x-2 text-sm text-white/80">
+                  <input
+                    type="checkbox"
+                    checked={form.runOnStartup}
+                    onChange={(e) => setForm((prev) => ({ ...prev, runOnStartup: e.target.checked }))}
+                    className="h-4 w-4 rounded border-white/20 bg-white/10"
+                  />
+                  <span>启动时执行一次</span>
+                </label>
+                <label className="flex items-center space-x-2 text-sm text-white/80">
+                  <input
+                    type="checkbox"
+                    checked={form.requireOverride}
+                    onChange={(e) => setForm((prev) => ({ ...prev, requireOverride: e.target.checked }))}
+                    className="h-4 w-4 rounded border-white/20 bg-white/10"
+                  />
+                  <span>需要公司 Override</span>
+                </label>
+                <label className="flex flex-col space-y-1 text-sm text-white/80">
+                  <span>Flow</span>
+                  <select
+                    value={form.flow}
+                    onChange={(e) => setForm((prev) => ({ ...prev, flow: e.target.value as 'LIMITED' | 'UNLIMITED' }))}
+                    className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+                  >
+                    <option value="UNLIMITED">UNLIMITED</option>
+                    <option value="LIMITED">LIMITED</option>
+                  </select>
+                </label>
+              </div>
+
+              <label className="flex flex-col space-y-1 text-sm text-white/80">
+                <span>Base Options（JSON）</span>
+                <textarea
+                  value={form.baseOptionsJson}
+                  onChange={(e) => setForm((prev) => ({ ...prev, baseOptionsJson: e.target.value }))}
+                  rows={6}
+                  className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-white focus:border-white/40 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col space-y-1 text-sm text-white/80">
+                <span>Categories（JSON 数组）</span>
+                <textarea
+                  value={form.categoriesJson}
+                  onChange={(e) => setForm((prev) => ({ ...prev, categoriesJson: e.target.value }))}
+                  rows={6}
+                  className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-white focus:border-white/40 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col space-y-1 text-sm text-white/80">
+                <span>Companies（JSON 数组）</span>
+                <textarea
+                  value={form.companiesJson}
+                  onChange={(e) => setForm((prev) => ({ ...prev, companiesJson: e.target.value }))}
+                  rows={8}
+                  className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-white focus:border-white/40 focus:outline-none"
+                />
+              </label>
+
+              {message && <p className="text-sm text-emerald-300">{message}</p>}
+              {errorMsg && <p className="text-sm text-rose-300">{errorMsg}</p>}
+
+              <div className="flex items-center space-x-3">
+                <button
+                  type="submit"
+                  disabled={saveMutation.isPending}
+                  className="rounded-md bg-white/10 px-4 py-2 text-sm font-medium text-white hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {saveMutation.isPending ? '保存中...' : '保存'}
+                </button>
+                {selectedId !== 'new' && selectedId !== null && (
+                  <button
+                    type="button"
+                    onClick={() => selectedId && typeof selectedId === 'number' && deleteMutation.mutate(selectedId)}
+                    className="rounded-md bg-rose-500/20 px-4 py-2 text-sm font-medium text-rose-200 hover:bg-rose-500/30"
+                  >
+                    删除
+                  </button>
+                )}
+              </div>
+            </form>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/vibe-jobs-view/app/(admin)/admin/ingestion-settings/page.tsx
+++ b/vibe-jobs-view/app/(admin)/admin/ingestion-settings/page.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FormEvent, useEffect, useState } from 'react';
+
+interface IngestionSettingsResponse {
+  fixedDelayMs: number;
+  initialDelayMs: number;
+  pageSize: number;
+  mode: 'RECENT' | 'COMPANIES';
+  companies: string[];
+  recentDays: number;
+  concurrency: number;
+  companyOverrides: Record<string, unknown>;
+  locationFilter: unknown;
+  roleFilter: unknown;
+  updatedAt: string;
+}
+
+async function fetchSettings(): Promise<IngestionSettingsResponse> {
+  const res = await fetch('/api/admin/ingestion-settings', { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('无法获取采集配置');
+  }
+  return res.json();
+}
+
+export default function IngestionSettingsPage() {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, error } = useQuery({ queryKey: ['admin', 'ingestion-settings'], queryFn: fetchSettings });
+  const [fixedDelayMs, setFixedDelayMs] = useState('3600000');
+  const [initialDelayMs, setInitialDelayMs] = useState('10000');
+  const [pageSize, setPageSize] = useState('100');
+  const [recentDays, setRecentDays] = useState('7');
+  const [concurrency, setConcurrency] = useState('4');
+  const [mode, setMode] = useState<'RECENT' | 'COMPANIES'>('RECENT');
+  const [companiesText, setCompaniesText] = useState('');
+  const [locationJson, setLocationJson] = useState('');
+  const [roleJson, setRoleJson] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (data) {
+      setFixedDelayMs(String(data.fixedDelayMs));
+      setInitialDelayMs(String(data.initialDelayMs));
+      setPageSize(String(data.pageSize));
+      setRecentDays(String(data.recentDays));
+      setConcurrency(String(data.concurrency));
+      setMode(data.mode);
+      setCompaniesText((data.companies || []).join('\n'));
+      setLocationJson(JSON.stringify(data.locationFilter ?? {}, null, 2));
+      setRoleJson(JSON.stringify(data.roleFilter ?? {}, null, 2));
+      setMessage(null);
+      setErrorMsg(null);
+    }
+  }, [data]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload: Record<string, unknown>) => {
+      const res = await fetch('/api/admin/ingestion-settings', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || '保存失败');
+      }
+      return res.json();
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['admin', 'ingestion-settings'] });
+      setMessage('保存成功，新的调度配置将在几秒内生效。');
+      setErrorMsg(null);
+    },
+    onError: (err: unknown) => {
+      setMessage(null);
+      setErrorMsg(err instanceof Error ? err.message : '保存失败');
+    },
+  });
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!data) return;
+
+    try {
+      const location = locationJson.trim() ? JSON.parse(locationJson) : {};
+      const role = roleJson.trim() ? JSON.parse(roleJson) : {};
+      const companies = companiesText
+        .split(/\r?\n/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+
+      const payload = {
+        fixedDelayMs: Number(fixedDelayMs) || data.fixedDelayMs,
+        initialDelayMs: Number(initialDelayMs) || data.initialDelayMs,
+        pageSize: Number(pageSize) || data.pageSize,
+        mode,
+        companies,
+        recentDays: Number(recentDays) || data.recentDays,
+        concurrency: Number(concurrency) || data.concurrency,
+        companyOverrides: data.companyOverrides ?? {},
+        locationFilter: location,
+        roleFilter: role,
+      };
+      mutation.mutate(payload);
+    } catch (err) {
+      setMessage(null);
+      setErrorMsg(err instanceof Error ? err.message : '无法解析 JSON 配置');
+    }
+  };
+
+  if (isLoading) {
+    return <p className="text-white/80">加载中...</p>;
+  }
+
+  if (isError || !data) {
+    return <p className="text-red-300">{(error as Error)?.message ?? '加载失败'}</p>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-white">采集调度配置</h2>
+        <p className="text-sm text-white/70">修改后保存即可，后台会自动调整定时任务与线程池。</p>
+      </div>
+      <form className="space-y-6" onSubmit={handleSubmit}>
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>固定延迟（毫秒）</span>
+            <input
+              value={fixedDelayMs}
+              onChange={(e) => setFixedDelayMs(e.target.value)}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+              type="number"
+              min={1000}
+              step={1000}
+            />
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>初始延迟（毫秒）</span>
+            <input
+              value={initialDelayMs}
+              onChange={(e) => setInitialDelayMs(e.target.value)}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+              type="number"
+              min={0}
+              step={1000}
+            />
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>分页大小</span>
+            <input
+              value={pageSize}
+              onChange={(e) => setPageSize(e.target.value)}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+              type="number"
+              min={1}
+            />
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>并发线程数</span>
+            <input
+              value={concurrency}
+              onChange={(e) => setConcurrency(e.target.value)}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+              type="number"
+              min={1}
+            />
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>模式</span>
+            <select
+              value={mode}
+              onChange={(e) => setMode(e.target.value as 'RECENT' | 'COMPANIES')}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+            >
+              <option value="RECENT">RECENT（按最近天数）</option>
+              <option value="COMPANIES">COMPANIES（按公司白名单）</option>
+            </select>
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>最近天数（RECENT 模式）</span>
+            <input
+              value={recentDays}
+              onChange={(e) => setRecentDays(e.target.value)}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 text-white focus:border-white/40 focus:outline-none"
+              type="number"
+              min={1}
+            />
+          </label>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>公司白名单（每行一个）</span>
+            <textarea
+              value={companiesText}
+              onChange={(e) => setCompaniesText(e.target.value)}
+              rows={6}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-sm text-white focus:border-white/40 focus:outline-none"
+            />
+          </label>
+          <div className="space-y-4">
+            <div>
+              <span className="block text-sm text-white/80">最近更新时间</span>
+              <p className="text-sm text-white/60">{new Date(data.updatedAt).toLocaleString()}</p>
+            </div>
+            <div className="rounded-lg border border-white/10 bg-white/5 p-3 text-xs text-white/60">
+              <p>说明：</p>
+              <ul className="mt-2 list-disc space-y-1 pl-5">
+                <li>调度参数会在保存后自动推送给调度线程。</li>
+                <li>并发度调整会实时更新线程池，无需重启。</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>Location Filter（JSON）</span>
+            <textarea
+              value={locationJson}
+              onChange={(e) => setLocationJson(e.target.value)}
+              rows={10}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-white focus:border-white/40 focus:outline-none"
+            />
+          </label>
+          <label className="flex flex-col space-y-2 text-sm text-white/80">
+            <span>Role Filter（JSON）</span>
+            <textarea
+              value={roleJson}
+              onChange={(e) => setRoleJson(e.target.value)}
+              rows={10}
+              className="rounded-md border border-white/10 bg-white/5 px-3 py-2 font-mono text-xs text-white focus:border-white/40 focus:outline-none"
+            />
+          </label>
+        </div>
+
+        {message && <p className="text-sm text-emerald-300">{message}</p>}
+        {errorMsg && <p className="text-sm text-rose-300">{errorMsg}</p>}
+
+        <button
+          type="submit"
+          disabled={mutation.isPending}
+          className="rounded-lg bg-white/10 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {mutation.isPending ? '保存中...' : '保存配置'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/vibe-jobs-view/app/(admin)/admin/layout.tsx
+++ b/vibe-jobs-view/app/(admin)/admin/layout.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { ReactNode, useEffect } from 'react';
+import { useAuth } from '@/lib/auth';
+
+const ALLOWED_EMAIL = '975022570yp@gmail.com';
+
+function NavLink({ href, label }: { href: string; label: string }) {
+  const pathname = usePathname();
+  const active = pathname === href;
+  return (
+    <Link
+      href={href}
+      className={`rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+        active ? 'bg-white/10 text-white' : 'text-white/70 hover:text-white hover:bg-white/10'
+      }`}
+    >
+      {label}
+    </Link>
+  );
+}
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  const { user, loading, logout } = useAuth();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      const redirectTo = pathname?.startsWith('/admin') ? pathname : '/admin';
+      router.replace(`/login?redirect=${encodeURIComponent(redirectTo)}`);
+    }
+  }, [loading, pathname, router, user]);
+
+  if (loading || !user) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-lg font-semibold">正在验证身份...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (user.email !== ALLOWED_EMAIL) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white flex items-center justify-center">
+        <div className="max-w-md text-center space-y-4">
+          <h1 className="text-2xl font-semibold">无权限访问后台</h1>
+          <p className="text-sm text-white/70">当前账号 {user.email} 不在允许名单内。</p>
+          <button
+            onClick={() => logout()}
+            className="rounded-md bg-white/10 px-4 py-2 text-sm font-medium hover:bg-white/20"
+          >
+            退出登录
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+      <header className="border-b border-white/10 bg-white/5 backdrop-blur">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+          <div>
+            <h1 className="text-xl font-semibold">Elaine Jobs 管理后台</h1>
+            <p className="text-xs text-white/60">欢迎回来，{user.email}</p>
+          </div>
+          <button
+            onClick={() => logout()}
+            className="rounded-md bg-white/10 px-3 py-2 text-sm font-medium hover:bg-white/20"
+          >
+            退出
+          </button>
+        </div>
+      </header>
+      <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 px-6 py-10 lg:grid-cols-[220px_1fr]">
+        <nav className="space-y-2 rounded-xl border border-white/10 bg-white/5 p-4 shadow-lg shadow-black/20">
+          <NavLink href="/admin" label="概览" />
+          <NavLink href="/admin/ingestion-settings" label="采集调度" />
+          <NavLink href="/admin/data-sources" label="数据源管理" />
+        </nav>
+        <main className="rounded-xl border border-white/10 bg-white/5 p-6 shadow-lg shadow-black/20">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/vibe-jobs-view/app/(admin)/admin/page.tsx
+++ b/vibe-jobs-view/app/(admin)/admin/page.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+export default function AdminHomePage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold text-white">后台总览</h2>
+        <p className="text-sm text-white/70">在这里可以实时调整采集调度、数据源以及公司清单。</p>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Link
+          href="/admin/ingestion-settings"
+          className="rounded-xl border border-white/10 bg-white/5 p-4 hover:border-white/30 hover:bg-white/10"
+        >
+          <h3 className="text-lg font-semibold text-white">采集调度</h3>
+          <p className="text-sm text-white/70">修改抓取间隔、并发度以及过滤器配置，几秒内生效。</p>
+        </Link>
+        <Link
+          href="/admin/data-sources"
+          className="rounded-xl border border-white/10 bg-white/5 p-4 hover:border-white/30 hover:bg-white/10"
+        >
+          <h3 className="text-lg font-semibold text-white">数据源管理</h3>
+          <p className="text-sm text-white/70">维护各类数据源、公司列表与运行开关。</p>
+        </Link>
+      </div>
+      <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-white/60">
+        <p className="font-medium text-white">提示</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>所有改动都会记录在审计日志中，方便追溯。</li>
+          <li>调度配置保存后 1-2 秒内自动触发重新调度。</li>
+          <li>数据源保存后会自动刷新客户端缓存，无需重启服务。</li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/vibe-jobs-view/app/api/admin/data-sources/[id]/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[id]/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+function resolveToken(req: NextRequest): string | null {
+  const headerToken = req.headers.get('x-session-token');
+  const cookieToken = cookies().get('vj_session')?.value;
+  const token = headerToken?.trim() || cookieToken?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+async function forward(req: NextRequest, params: { id: string }, method: 'GET' | 'PUT' | 'DELETE') {
+  const token = resolveToken(req);
+  if (!token) {
+    return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
+  }
+  const base = resolveBackendBase();
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
+  }
+  const upstream = buildBackendUrl(base, `/admin/data-sources/${params.id}`);
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'x-session-token': token,
+  };
+  let body: string | undefined;
+  if (method === 'PUT') {
+    body = await req.text();
+    headers['content-type'] = req.headers.get('content-type') || 'application/json';
+  }
+  const response = await fetch(upstream, {
+    method,
+    headers,
+    body,
+    cache: 'no-store',
+  });
+  if (method === 'DELETE') {
+    return NextResponse.json(null, { status: response.status });
+  }
+  const text = await response.text();
+  try {
+    const json = text ? JSON.parse(text) : null;
+    return NextResponse.json(json, { status: response.status });
+  } catch {
+    return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend', raw: text }, { status: 502 });
+  }
+}
+
+export async function GET(req: NextRequest, context: { params: { id: string } }) {
+  return forward(req, context.params, 'GET');
+}
+
+export async function PUT(req: NextRequest, context: { params: { id: string } }) {
+  return forward(req, context.params, 'PUT');
+}
+
+export async function DELETE(req: NextRequest, context: { params: { id: string } }) {
+  return forward(req, context.params, 'DELETE');
+}

--- a/vibe-jobs-view/app/api/admin/data-sources/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+function resolveToken(req: NextRequest): string | null {
+  const headerToken = req.headers.get('x-session-token');
+  const cookieToken = cookies().get('vj_session')?.value;
+  const token = headerToken?.trim() || cookieToken?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+async function forward(req: NextRequest, method: 'GET' | 'POST') {
+  const token = resolveToken(req);
+  if (!token) {
+    return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
+  }
+  const base = resolveBackendBase();
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
+  }
+  const upstream = buildBackendUrl(base, '/admin/data-sources');
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'x-session-token': token,
+  };
+  let body: string | undefined;
+  if (method === 'POST') {
+    body = await req.text();
+    headers['content-type'] = req.headers.get('content-type') || 'application/json';
+  }
+  const response = await fetch(upstream, {
+    method,
+    headers,
+    body,
+    cache: 'no-store',
+  });
+  const text = await response.text();
+  try {
+    const json = text ? JSON.parse(text) : null;
+    return NextResponse.json(json, { status: response.status });
+  } catch {
+    return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend', raw: text }, { status: 502 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return forward(req, 'GET');
+}
+
+export async function POST(req: NextRequest) {
+  return forward(req, 'POST');
+}

--- a/vibe-jobs-view/app/api/admin/ingestion-settings/route.ts
+++ b/vibe-jobs-view/app/api/admin/ingestion-settings/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+function resolveSessionToken(req: NextRequest): string | null {
+  const headerToken = req.headers.get('x-session-token');
+  const cookieToken = cookies().get('vj_session')?.value;
+  const token = headerToken?.trim() || cookieToken?.trim();
+  return token && token.length > 0 ? token : null;
+}
+
+async function proxy(req: NextRequest, method: 'GET' | 'PUT') {
+  const token = resolveSessionToken(req);
+  if (!token) {
+    return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
+  }
+
+  const base = resolveBackendBase();
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
+  }
+
+  const upstream = buildBackendUrl(base, '/admin/ingestion-settings');
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'x-session-token': token,
+  };
+
+  let body: string | undefined;
+  if (method === 'PUT') {
+    body = await req.text();
+    headers['content-type'] = req.headers.get('content-type') || 'application/json';
+  }
+
+  const response = await fetch(upstream, {
+    method,
+    headers,
+    body,
+    cache: 'no-store',
+  });
+
+  const text = await response.text();
+  try {
+    const json = text ? JSON.parse(text) : null;
+    return NextResponse.json(json, { status: response.status });
+  } catch {
+    return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend', raw: text }, { status: 502 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, 'GET');
+}
+
+export async function PUT(req: NextRequest) {
+  return proxy(req, 'PUT');
+}


### PR DESCRIPTION
## Summary
- add admin backend services, database tables, and HTTP endpoints to manage ingestion settings and job data sources with audit logging and access control
- refactor ingestion scheduling to use a dedicated executor manager, task scheduler, and cache invalidation when settings or data sources change
- create Next.js admin console with API proxies, protected layout, and forms for adjusting ingestion parameters and data source definitions

## Testing
- mvn -f vibe-jobs-aggregator/pom.xml -q test *(fails: Maven Central access returns 403 in container)*
- pnpm lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68de8031fd908328a5f24a9eef0a50eb