### PR TITLE
Support relative backend base URLs for API proxies

### DIFF
--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/[companyId]/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/[companyId]/route.ts
@@ -14,7 +14,7 @@ async function forward(req: NextRequest, params: { codeOrId: string; companyId: 
   if (!token) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/bulk/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/bulk/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest, context: { params: { codeOrId: stri
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
 
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/route.ts
@@ -14,7 +14,7 @@ async function forward(req: NextRequest, params: { codeOrId: string }, method: '
   if (!token) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/paged/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/paged/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: NextRequest, context: { params: { codeOrId: strin
   // }
   
   // Try to fetch from backend first, if it fails use mock data
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (base) {
     try {
       const { searchParams } = new URL(req.url);

--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/route.ts
@@ -14,7 +14,7 @@ async function forward(req: NextRequest, params: { codeOrId: string }, method: '
   if (!token) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/data-sources/bulk/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/bulk/route.ts
@@ -15,7 +15,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
   
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/data-sources/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/route.ts
@@ -14,7 +14,7 @@ async function forward(req: NextRequest, method: 'GET' | 'POST') {
   if (!token) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/admin/ingestion-settings/route.ts
+++ b/vibe-jobs-view/app/api/admin/ingestion-settings/route.ts
@@ -15,7 +15,7 @@ async function proxy(req: NextRequest, method: 'GET' | 'PUT') {
     return NextResponse.json({ code: 'NO_SESSION', message: 'Admin session required' }, { status: 401 });
   }
 
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/auth/request-code/route.ts
+++ b/vibe-jobs-view/app/api/auth/request-code/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ code: 'INVALID_EMAIL', message: 'Email is required.' }, { status: 400 });
   }
 
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/auth/session/route.ts
+++ b/vibe-jobs-view/app/api/auth/session/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ code: 'NO_SESSION', message: 'No active session.' }, { status: 401 });
   }
 
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/auth/verify-code/route.ts
+++ b/vibe-jobs-view/app/api/auth/verify-code/route.ts
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ code: 'INVALID_CODE', message: 'Verification code is required.' }, { status: 400 });
   }
 
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
   }

--- a/vibe-jobs-view/app/api/jobs/[id]/detail/route.ts
+++ b/vibe-jobs-view/app/api/jobs/[id]/detail/route.ts
@@ -1,41 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
 
 type Params = { params: { id: string } };
 
-function buildBackendUrl(base: string, path: string) {
-  const url = new URL(base);
-  const basePath = url.pathname.replace(/\/$/, '');
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
-  const prefix = basePath.endsWith('/api') ? basePath : `${basePath}/api`;
-  url.pathname = `${prefix}${normalizedPath}`;
-  return url;
-}
-
-function resolveBackendBase(): string | null {
-  const runtimeBase = process.env['BACKEND_BASE_URL'];
-  if (runtimeBase && runtimeBase.trim()) {
-    return runtimeBase.trim();
-  }
-
-  const candidates = [
-    process.env['NEXT_PUBLIC_BACKEND_BASE'],
-    process.env['NEXT_PUBLIC_API_BASE'],
-  ];
-
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const trimmed = candidate.trim();
-    if (trimmed && /^(https?:)?\/\//.test(trimmed)) {
-      return trimmed;
-    }
-  }
-
-  return null;
-}
-
-export async function GET(_req: NextRequest, { params }: Params) {
+export async function GET(req: NextRequest, { params }: Params) {
   const { id } = params;
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
 
   if (!base) {
     return NextResponse.json({ error: 'Backend base URL not configured' }, { status: 500 });

--- a/vibe-jobs-view/app/api/jobs/route.ts
+++ b/vibe-jobs-view/app/api/jobs/route.ts
@@ -3,7 +3,7 @@ import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
-  const base = resolveBackendBase();
+  const base = resolveBackendBase(req);
   if (!base) {
     return NextResponse.json({ error: 'Backend base URL not configured' }, { status: 500 });
   }

--- a/vibe-jobs-view/lib/backend.ts
+++ b/vibe-jobs-view/lib/backend.ts
@@ -1,16 +1,86 @@
-export function resolveBackendBase(): string | null {
+import type { NextRequest } from 'next/server';
+import { headers as nextHeaders } from 'next/headers';
+
+type RequestLike = NextRequest | Request;
+
+function firstHeaderValue(value: string | null): string | null {
+  if (!value) return null;
+  const first = value.split(',')[0]?.trim();
+  return first && first.length > 0 ? first : null;
+}
+
+function resolveOrigin(request?: RequestLike): string | null {
+  if (request) {
+    const maybeNextRequest = request as Partial<NextRequest>;
+    const nextUrl = maybeNextRequest.nextUrl as URL | undefined;
+    if (nextUrl?.origin) {
+      return nextUrl.origin;
+    }
+
+    const requestHeaders = request.headers;
+    const host = requestHeaders.get('x-forwarded-host') || requestHeaders.get('host');
+    if (host) {
+      const proto =
+        firstHeaderValue(requestHeaders.get('x-forwarded-proto')) ||
+        firstHeaderValue(requestHeaders.get('protocol')) ||
+        (host.includes('localhost') || host.startsWith('127.') ? 'http' : null) ||
+        'https';
+      return `${proto}://${host}`;
+    }
+  }
+
+  try {
+    const headerList = nextHeaders();
+    const host = headerList.get('x-forwarded-host') || headerList.get('host');
+    if (!host) {
+      return null;
+    }
+    const proto =
+      firstHeaderValue(headerList.get('x-forwarded-proto')) ||
+      (host.includes('localhost') || host.startsWith('127.') ? 'http' : 'https');
+    return `${proto}://${host}`;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeProtocolRelativeUrl(url: string, origin: string | null): string {
+  if (!url.startsWith('//')) {
+    return url;
+  }
+  const effectiveOrigin = origin || 'https://localhost';
+  const protocol = effectiveOrigin.split('://')[0] || 'https';
+  return `${protocol}:${url}`;
+}
+
+export function resolveBackendBase(request?: RequestLike): string | null {
   const runtimeBase = process.env['BACKEND_BASE_URL'];
   if (runtimeBase && runtimeBase.trim()) {
     return runtimeBase.trim();
   }
+
+  const origin = resolveOrigin(request);
 
   const candidates = [process.env['NEXT_PUBLIC_BACKEND_BASE'], process.env['NEXT_PUBLIC_API_BASE']];
 
   for (const candidate of candidates) {
     if (!candidate) continue;
     const trimmed = candidate.trim();
-    if (trimmed && /^(https?:)?\/\//.test(trimmed)) {
+    if (!trimmed) continue;
+
+    if (/^https?:\/\//.test(trimmed)) {
       return trimmed;
+    }
+
+    if (/^\/\//.test(trimmed)) {
+      return normalizeProtocolRelativeUrl(trimmed, origin);
+    }
+
+    if (trimmed.startsWith('/')) {
+      if (origin) {
+        return `${origin}${trimmed}`;
+      }
+      continue;
     }
   }
 


### PR DESCRIPTION
## Summary
- allow resolveBackendBase to derive an absolute origin from incoming requests when only a relative backend path is configured
- update API proxy routes to pass their NextRequest into resolveBackendBase so relative configurations work after deployment
- reuse the shared backend helpers in the job detail proxy

## Testing
- pnpm lint *(fails: prompts for ESLint configuration and requires interactive input)*

------
https://chatgpt.com/codex/tasks/task_e_68e11cbf49b8832895b2769d26ca5e19