### PR TITLE
Fix 500 error when deleting data sources

### DIFF
--- a/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/[companyId]/route.ts
+++ b/vibe-jobs-view/app/api/admin/data-sources/[codeOrId]/companies/[companyId]/route.ts
@@ -9,6 +9,21 @@ function resolveToken(req: NextRequest): string | null {
   return token && token.length > 0 ? token : null;
 }
 
+function cloneUpstreamHeaders(response: Response): Headers {
+  const headers = new Headers();
+  response.headers.forEach((value, key) => {
+    if (key.toLowerCase() === 'content-length') {
+      return;
+    }
+    headers.set(key, value);
+  });
+  return headers;
+}
+
+function isNoBodyStatus(status: number): boolean {
+  return status === 101 || status === 204 || status === 205 || status === 304;
+}
+
 async function forward(req: NextRequest, params: { codeOrId: string; companyId: string }, method: 'GET' | 'PUT' | 'DELETE') {
   const token = resolveToken(req);
   if (!token) {
@@ -34,13 +49,30 @@ async function forward(req: NextRequest, params: { codeOrId: string; companyId: 
     body,
     cache: 'no-store',
   });
+  const responseHeaders = cloneUpstreamHeaders(response);
   if (method === 'DELETE') {
-    return NextResponse.json(null, { status: response.status });
+    if (isNoBodyStatus(response.status)) {
+      return new NextResponse(null, { status: response.status, headers: responseHeaders });
+    }
+    const text = await response.text();
+    const contentType = responseHeaders.get('content-type') ?? '';
+    if (contentType.includes('application/json')) {
+      try {
+        const json = text ? JSON.parse(text) : null;
+        return NextResponse.json(json, { status: response.status, headers: responseHeaders });
+      } catch {
+        return NextResponse.json(
+          { code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend', raw: text },
+          { status: 502 }
+        );
+      }
+    }
+    return new NextResponse(text, { status: response.status, headers: responseHeaders });
   }
   const text = await response.text();
   try {
     const json = text ? JSON.parse(text) : null;
-    return NextResponse.json(json, { status: response.status });
+    return NextResponse.json(json, { status: response.status, headers: responseHeaders });
   } catch {
     return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend', raw: text }, { status: 502 });
   }


### PR DESCRIPTION
## Summary
- avoid returning JSON bodies for upstream DELETE responses that include no content
- forward upstream headers and content types when proxying admin data-source DELETE calls
- ensure the admin data-source proxy can surface non-JSON error payloads without throwing

## Testing
- pnpm lint *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e2527da5d88328aaf68afb8b9031cd