### PR TITLE
feat: track ingestion cursor timestamps

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionCursorService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/IngestionCursorService.java
@@ -1,0 +1,105 @@
+package com.vibe.jobs.ingestion;
+
+import com.vibe.jobs.ingestion.domain.IngestionCursor;
+import com.vibe.jobs.ingestion.domain.IngestionCursorKey;
+import com.vibe.jobs.ingestion.infrastructure.jpa.IngestionCursorEntity;
+import com.vibe.jobs.ingestion.infrastructure.jpa.SpringDataIngestionCursorRepository;
+import com.vibe.jobs.domain.Job;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+public class IngestionCursorService {
+
+    private final SpringDataIngestionCursorRepository repository;
+
+    public IngestionCursorService(SpringDataIngestionCursorRepository repository) {
+        this.repository = repository;
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<IngestionCursor> find(IngestionCursorKey key) {
+        IngestionCursorKey normalized = normalize(key);
+        return repository.findBySourceNameAndCompanyAndCategory(
+                        normalized.sourceName(),
+                        normalized.company(),
+                        normalized.category())
+                .map(this::toDomain);
+    }
+
+    @Transactional
+    public IngestionCursor updatePosition(IngestionCursorKey key, Job job) {
+        if (job == null) {
+            throw new IllegalArgumentException("job must not be null");
+        }
+        Instant postedAt = job.getPostedAt();
+        String externalId = job.getExternalId();
+        return updatePosition(key, postedAt, externalId, null);
+    }
+
+    @Transactional
+    public IngestionCursor updatePosition(IngestionCursorKey key,
+                                          Instant lastPostedAt,
+                                          String lastExternalId,
+                                          String nextPageToken) {
+        IngestionCursorKey normalized = normalize(key);
+        IngestionCursorEntity entity = repository.findBySourceNameAndCompanyAndCategory(
+                normalized.sourceName(), normalized.company(), normalized.category())
+                .orElseGet(() -> {
+                    IngestionCursorEntity created = new IngestionCursorEntity();
+                    created.setSourceCode(normalized.sourceCode());
+                    created.setSourceName(normalized.sourceName());
+                    created.setCompany(normalized.company());
+                    created.setCategory(normalized.category());
+                    created.setLastIngestedAt(Instant.now());
+                    return created;
+                });
+        entity.setSourceCode(normalized.sourceCode());
+        entity.setSourceName(normalized.sourceName());
+        entity.setCompany(normalized.company());
+        entity.setCategory(normalized.category());
+        entity.setLastPostedAt(lastPostedAt);
+        entity.setLastExternalId(lastExternalId);
+        entity.setNextPageToken(nextPageToken);
+        entity.setLastIngestedAt(Instant.now());
+        IngestionCursorEntity saved = repository.save(entity);
+        return toDomain(saved);
+    }
+
+    private IngestionCursor toDomain(IngestionCursorEntity entity) {
+        return new IngestionCursor(
+                entity.getSourceCode(),
+                entity.getSourceName(),
+                entity.getCompany(),
+                entity.getCategory(),
+                entity.getLastPostedAt(),
+                entity.getLastExternalId(),
+                entity.getNextPageToken(),
+                entity.getLastIngestedAt(),
+                entity.getCreateTime(),
+                entity.getUpdateTime()
+        );
+    }
+
+    private IngestionCursorKey normalize(IngestionCursorKey key) {
+        if (key == null) {
+            throw new IllegalArgumentException("key must not be null");
+        }
+        return IngestionCursorKey.of(
+                sanitize(key.sourceCode()),
+                sanitize(key.sourceName()),
+                sanitize(key.company()),
+                sanitize(key.category())
+        );
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim();
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/domain/IngestionCursor.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/domain/IngestionCursor.java
@@ -1,0 +1,51 @@
+package com.vibe.jobs.ingestion.domain;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record IngestionCursor(
+        String sourceCode,
+        String sourceName,
+        String company,
+        String category,
+        Instant lastPostedAt,
+        String lastExternalId,
+        String nextPageToken,
+        Instant lastIngestedAt,
+        Instant createTime,
+        Instant updateTime
+) {
+    public IngestionCursor {
+        sourceCode = normalize(sourceCode);
+        sourceName = normalize(sourceName);
+        company = normalize(company);
+        category = normalize(category);
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim();
+    }
+
+    public boolean hasPosition() {
+        return lastPostedAt != null || (lastExternalId != null && !lastExternalId.isBlank());
+    }
+
+    public IngestionCursor withNextPageToken(String token) {
+        if (Objects.equals(token, nextPageToken)) {
+            return this;
+        }
+        return new IngestionCursor(sourceCode, sourceName, company, category, lastPostedAt, lastExternalId, token, lastIngestedAt, createTime, updateTime);
+    }
+
+    public IngestionCursor advanceTo(Instant postedAt, String externalId) {
+        if (postedAt == null && (externalId == null || externalId.isBlank())) {
+            return this;
+        }
+        Instant now = Instant.now();
+        Instant effectiveCreateTime = createTime == null ? now : createTime;
+        return new IngestionCursor(sourceCode, sourceName, company, category, postedAt, externalId, nextPageToken, now, effectiveCreateTime, now);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/domain/IngestionCursorKey.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/domain/IngestionCursorKey.java
@@ -1,0 +1,37 @@
+package com.vibe.jobs.ingestion.domain;
+
+import java.util.Objects;
+
+public record IngestionCursorKey(String sourceCode,
+                                 String sourceName,
+                                 String company,
+                                 String category) {
+
+    public IngestionCursorKey {
+        sourceCode = normalize(sourceCode);
+        sourceName = normalize(sourceName);
+        company = normalize(company);
+        category = normalize(category);
+    }
+
+    public static IngestionCursorKey of(String sourceCode, String sourceName, String company, String category) {
+        return new IngestionCursorKey(sourceCode, sourceName, company, category);
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.trim();
+    }
+
+    public boolean matches(IngestionCursor cursor) {
+        if (cursor == null) {
+            return false;
+        }
+        return Objects.equals(cursor.sourceCode(), sourceCode)
+                && Objects.equals(cursor.sourceName(), sourceName)
+                && Objects.equals(cursor.company(), company)
+                && Objects.equals(cursor.category(), category);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/infrastructure/jpa/IngestionCursorEntity.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/infrastructure/jpa/IngestionCursorEntity.java
@@ -1,0 +1,188 @@
+package com.vibe.jobs.ingestion.infrastructure.jpa;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "ingestion_cursors", uniqueConstraints = {
+        @UniqueConstraint(name = "uq_ingestion_cursor", columnNames = {"source_name", "company", "category"})
+})
+public class IngestionCursorEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_code", nullable = false, length = 128)
+    private String sourceCode;
+
+    @Column(name = "source_name", nullable = false, length = 128)
+    private String sourceName;
+
+    @Column(name = "company", nullable = false, length = 128)
+    private String company;
+
+    @Column(name = "category", nullable = false, length = 128)
+    private String category;
+
+    @Column(name = "last_posted_at")
+    private Instant lastPostedAt;
+
+    @Column(name = "last_external_id", length = 256)
+    private String lastExternalId;
+
+    @Column(name = "next_page_token", length = 512)
+    private String nextPageToken;
+
+    @Column(name = "last_ingested_at", nullable = false)
+    private Instant lastIngestedAt;
+
+    @Column(name = "create_time", nullable = false, updatable = false)
+    private Instant createTime;
+
+    @Column(name = "update_time", nullable = false)
+    private Instant updateTime;
+
+    @Version
+    @Column(name = "version", nullable = false)
+    private Long version;
+
+    public IngestionCursorEntity() {
+    }
+
+    @PrePersist
+    public void onInsert() {
+        if (lastIngestedAt == null) {
+            lastIngestedAt = Instant.now();
+        }
+        if (createTime == null) {
+            createTime = Instant.now();
+        }
+        if (updateTime == null) {
+            updateTime = Instant.now();
+        }
+        if (company == null) {
+            company = "";
+        }
+        if (category == null) {
+            category = "";
+        }
+    }
+
+    @PreUpdate
+    public void onUpdate() {
+        lastIngestedAt = Instant.now();
+        updateTime = Instant.now();
+        if (createTime == null) {
+            createTime = updateTime;
+        }
+        if (company == null) {
+            company = "";
+        }
+        if (category == null) {
+            category = "";
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSourceCode() {
+        return sourceCode;
+    }
+
+    public void setSourceCode(String sourceCode) {
+        this.sourceCode = sourceCode;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public void setCompany(String company) {
+        this.company = company == null ? "" : company;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category == null ? "" : category;
+    }
+
+    public Instant getLastPostedAt() {
+        return lastPostedAt;
+    }
+
+    public void setLastPostedAt(Instant lastPostedAt) {
+        this.lastPostedAt = lastPostedAt;
+    }
+
+    public String getLastExternalId() {
+        return lastExternalId;
+    }
+
+    public void setLastExternalId(String lastExternalId) {
+        this.lastExternalId = lastExternalId;
+    }
+
+    public String getNextPageToken() {
+        return nextPageToken;
+    }
+
+    public void setNextPageToken(String nextPageToken) {
+        this.nextPageToken = nextPageToken;
+    }
+
+    public Instant getLastIngestedAt() {
+        return lastIngestedAt;
+    }
+
+    public void setLastIngestedAt(Instant lastIngestedAt) {
+        this.lastIngestedAt = lastIngestedAt;
+    }
+
+    public Instant getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Instant createTime) {
+        this.createTime = createTime;
+    }
+
+    public Instant getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(Instant updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/infrastructure/jpa/SpringDataIngestionCursorRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/ingestion/infrastructure/jpa/SpringDataIngestionCursorRepository.java
@@ -1,0 +1,9 @@
+package com.vibe.jobs.ingestion.infrastructure.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SpringDataIngestionCursorRepository extends JpaRepository<IngestionCursorEntity, Long> {
+    Optional<IngestionCursorEntity> findBySourceNameAndCompanyAndCategory(String sourceName, String company, String category);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/SourceClient.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/sources/SourceClient.java
@@ -1,9 +1,31 @@
 
 package com.vibe.jobs.sources;
+
+import com.vibe.jobs.ingestion.domain.IngestionCursor;
+
 import java.util.List;
 
 public interface SourceClient {
     String sourceName();
     List<FetchedJob> fetchPage(int page, int size) throws Exception;
-    default boolean supportsIncremental(){ return false; }
+
+    default boolean supportsIncremental() {
+        return false;
+    }
+
+    default FetchResult fetchSince(IngestionCursor cursor, int pageSize) throws Exception {
+        List<FetchedJob> jobs = fetchPage(1, pageSize);
+        boolean hasMore = jobs != null && !jobs.isEmpty();
+        return new FetchResult(jobs, null, hasMore);
+    }
+
+    record FetchResult(List<FetchedJob> jobs, String nextPageToken, boolean hasMore) {
+        public FetchResult {
+            jobs = jobs == null ? List.of() : List.copyOf(jobs);
+        }
+
+        public static FetchResult empty() {
+            return new FetchResult(List.of(), null, false);
+        }
+    }
 }

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V12__create_ingestion_cursors_table.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V12__create_ingestion_cursors_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS ingestion_cursors (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    source_code VARCHAR(128) NOT NULL,
+    source_name VARCHAR(128) NOT NULL,
+    company VARCHAR(128) NOT NULL,
+    category VARCHAR(128) NOT NULL,
+    last_posted_at TIMESTAMP NULL,
+    last_external_id VARCHAR(256) NULL,
+    next_page_token VARCHAR(512) NULL,
+    last_ingested_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    version BIGINT NOT NULL DEFAULT 0,
+    UNIQUE KEY uq_ingestion_cursor (source_name, company, category)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
## Summary
- add create_time and update_time columns to the ingestion_cursors table with lifecycle hooks that maintain them on insert and update
- expose the new timestamps through the ingestion cursor JPA entity and domain model so callers receive the metadata consistently

## Testing
- mvn -f vibe-jobs-aggregator/pom.xml test *(fails: unable to download spring-boot-starter-parent because Maven Central returns 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2602d88b88328ac2cef2c593a56d7