### PR TITLE
Implement job alert subscription pipeline

### DIFF
--- a/docs/subscription-alert-design.md
+++ b/docs/subscription-alert-design.md
@@ -1,0 +1,157 @@
+# Job Subscription Alert – Functional & Technical Design
+
+## 1. 背景与目标
+当前前端在第一次搜索或点击 “Create alert” 按钮时，会调用尚未实现的 `POST /subscription` 接口，后台未保存任何订阅配置，也没有定时发送邮件的逻辑。【F:vibe-jobs-view/app/(site)/page.tsx†L597-L622】本设计旨在落地“每日职位更新订阅”能力：
+
+- 支持登录用户在搜索页创建/管理订阅。
+- 后台每天在指定时间（默认 00:00，本地化为用户时区）检查匹配的新增职位，仅当有新增内容时发送邮件。
+- 为后续扩展短信/多频率提醒做好架构预留。
+
+## 2. 核心用户流程
+1. **首次搜索弹窗**：
+   - 未提示过的登录用户提交搜索表单时，前端弹出订阅 Modal，显示当前检索条件并允许确认/取消。【F:vibe-jobs-view/app/(site)/page.tsx†L597-L628】
+2. **手动创建**：
+   - 页面右上角或结果列表旁保留 “Create alert” 按钮，登录用户点击后可再次打开 Modal 创建新的订阅。
+3. **订阅管理**：
+   - 在用户 Profile 页面新增 “Job alerts” 面板，列出所有订阅（关键词+筛选条件+发送时间+上次发送日期），支持暂停/删除/修改时间。
+4. **邮件体验**：
+   - 邮件主题示例：“【Elaine Jobs】3 个新的上海数据分析职位”。
+   - 内容含：订阅条件摘要、新增职位列表（标题/公司/地点/发布时间/链接），末尾提供取消订阅链接。
+5. **退订/状态同步**：
+   - 邮件底部的 “取消订阅” 链接指向带 token 的一次性 URL，触发后将该订阅标记为 `inactive`。
+
+## 3. 系统架构 & 组件
+```
+Next.js (vibe-jobs-view)
+  └── 调用 `/api/subscriptions`（BFF）
+Spring Boot Aggregator (vibe-jobs-aggregator)
+  ├── REST Controller：JobSubscriptionController
+  ├── Service：JobSubscriptionService / JobAlertScheduler
+  ├── Repository：JobSubscriptionRepository / JobSubscriptionRunRepository
+  └── Email Sender：扩展现有 EmailSender -> JobAlertEmailSender
+MySQL
+  ├── auth_user（现有登录用户表）
+  └── job_alert_subscription, job_alert_delivery（新表）
+定时任务：Quartz / Spring `@Scheduled`（00:00 UTC+用户时区）
+第三方邮件服务：沿用 `EmailSender` SPI，实现批量模板发送
+```
+- 前端依旧直接命中聚合服务提供的 `/jobs` 搜索接口。【F:vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/JobController.java†L37-L107】
+- 后台订阅调度复用 `JobRepository` 的筛选逻辑，保持与搜索结果一致性。【F:vibe-jobs-aggregator/src/main/java/com/vibe/jobs/repo/JobRepository.java†L20-L66】
+- 用户身份与邮箱沿用 `auth_user` 表的 `UUID` 主键及邮箱字段，订阅记录通过外键关联。【F:vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/domain/UserAccount.java†L8-L66】
+
+## 4. 数据模型设计
+### 4.1 `job_alert_subscription`
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | BIGINT, PK, auto increment | 订阅 ID |
+| `user_id` | BINARY(16), FK → `auth_user.id` | 关联登录用户 |
+| `email` | VARCHAR(255) | 冗余存储发送邮箱（便于统计） |
+| `search_keyword` | VARCHAR(255) | 对应搜索输入框 `q` |
+| `company` | VARCHAR(255) | 公司过滤，可为空 |
+| `location` | VARCHAR(255) | 地点过滤，可为空 |
+| `level` | VARCHAR(100) | 职级过滤，可为空 |
+| `filters_json` | JSON | 扩展字段（remote、salaryMin 等） |
+| `schedule_hour` | TINYINT | 本地时区小时，默认 0 |
+| `timezone` | VARCHAR(64) | IANA 时区标识，默认 `Asia/Shanghai`（从用户设置或浏览器推断） |
+| `last_notified_at` | DATETIME | 上次成功发送时间 |
+| `last_seen_cursor` | VARBINARY(32) | 保存上次游标（`postedAt:id` 的 Base64） |
+| `status` | ENUM(`active`,`paused`,`cancelled`) | 状态管理 |
+| `created_at` / `updated_at` | DATETIME | 审计字段 |
+
+索引建议：
+- `idx_job_alert_user_status` (`user_id`, `status`)
+- `idx_job_alert_schedule` (`status`, `timezone`, `schedule_hour`)
+
+### 4.2 `job_alert_delivery`
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `id` | BIGINT PK |
+| `subscription_id` | BIGINT FK | 对应订阅 |
+| `delivered_at` | DATETIME | 实际发送时间 |
+| `job_count` | INT | 本次邮件包含职位数量 |
+| `job_ids` | JSON | 发送的职位 ID 数组（便于审计/排查） |
+| `status` | ENUM(`sent`,`skipped`,`failed`) | 运行结果 |
+| `error_message` | TEXT | 失败原因 |
+
+### 4.3 数据迁移
+- 新增 Flyway 脚本 `VXX__job_alert_subscription.sql`，创建上述两张表及索引。
+- 如需对现有 `auth_user` 增加 `timezone` 字段，可在同一次迁移内完成，否则可按需在用户设置中存储。
+
+## 5. 后端接口设计
+所有接口需携带登录态（复用现有邮箱验证码登录）。
+
+| 方法 & 路径 | 请求体 | 响应 | 说明 |
+| --- | --- | --- | --- |
+| `POST /api/subscriptions` | `{ keyword, company?, location?, level?, filters?, timezone?, scheduleHour? }` | `201 Created` + 订阅对象 | 创建订阅，默认 `status=active`，`scheduleHour` 为空则落地为 0 |
+| `GET /api/subscriptions` | - | 订阅数组 | 返回当前用户所有订阅及运行摘要 |
+| `PATCH /api/subscriptions/{id}` | `{ status?, scheduleHour?, timezone?, keyword?, ... }` | 更新后的对象 | 支持暂停、恢复、调整条件 |
+| `DELETE /api/subscriptions/{id}` | - | `204 No Content` | 软删除（`status=cancelled`） |
+| `POST /api/subscriptions/{id}/test` | - | `202 Accepted` | 触发一次即时测试邮件（仅管理员或自用调试） |
+| `POST /api/subscriptions/{id}/unsubscribe` | `{ token }` | `204` | 邮件退订链接访问后调用，验证 token 与订阅匹配 |
+
+返回对象字段：`id, keyword, company, location, level, filters, scheduleHour, timezone, status, lastNotifiedAt, createdAt`。
+
+## 6. 服务层与调度逻辑
+1. **JobSubscriptionService**
+   - 封装 CRUD，校验用户上限（例如最多 10 条订阅）。
+   - 负责生成/验证退订 token（`HMAC(userId + subscriptionId + secret)`）。
+
+2. **JobAlertScheduler**
+   - 基于 `@Scheduled(fixedDelay = 1m)` 拉取当前分钟需要运行的订阅：
+     - 计算用户时区的当前小时是否等于 `schedule_hour`，并确保 `status=active`。
+     - 使用分片或分布式锁（Redis/DB 行锁）避免重复执行。
+   - 每个订阅执行流程：
+     1. 根据订阅条件调用 `JobRepository.searchAfter`，传入 `last_seen_cursor` 对应的 postedAt/id 过滤，限制拉取数量（例如 50 条）。【F:vibe-jobs-aggregator/src/main/java/com/vibe/jobs/repo/JobRepository.java†L20-L66】
+     2. 若无新增职位：写入 `job_alert_delivery` 一条 `status=skipped` 的记录，更新 `last_seen_cursor`（保持游标最新，但不发送邮件）。
+     3. 若有新增：生成邮件内容，调用 `JobAlertEmailSender.sendDigest(...)`。成功后更新：
+        - `last_notified_at = now`
+        - `last_seen_cursor` 为结果集中最新职位的 `(postedAt,id)` 游标。
+        - 写入 `job_alert_delivery`，记录 jobIds/数量。
+     4. 若发送失败，记录 `status=failed` 和错误信息，调度器会在下一轮（例如 15 分钟后）重试，最多 3 次。
+
+3. **Email 发送**
+   - 在 `com.vibe.jobs.auth.spi.EmailSender` 基础上新增 `JobAlertEmailSender`（或扩展接口），提供 `sendDigest(EmailAddress to, JobAlertDigest payload)` 方法。【F:vibe-jobs-aggregator/src/main/java/com/vibe/jobs/auth/spi/EmailSender.java†L1-L9】
+   - 复用现有 SMTP/Mailgun 配置，新增 HTML 模板（Thymeleaf/Freemarker）。
+
+4. **并发控制**
+   - 单次调度批量拉取 100 条订阅，使用线程池并发处理；邮件发送与查询拆分异步队列，保障在高峰期也能在 5 分钟内完成。
+
+## 7. 前端改动摘要
+- 在 BFF 层新增 `/api/subscriptions` 路由，作为后端 `vibe-jobs-aggregator` `/subscriptions` 的代理，复用现有 `API_BASE` 配置。
+- 搜索页调用成功后，应提示用户“订阅创建成功”，并在失败时展示错误消息（例如邮箱未验证、超出数量上限）。
+- Profile 页面新增订阅管理界面（表格 + 新建按钮）。
+- 若用户未登录：
+  - 搜索时弹出的 Modal 替换为登录提示，点击跳转到登录流程。
+
+## 8. 安全与合规
+- 退订 token 设置 24 小时有效期，点击后立即失效并标记订阅为 `cancelled`。
+- 限制每个用户每日最多发送邮件 1 次/订阅，防止频繁提醒。
+- 日志中避免记录完整职位列表，仅记录 jobIds 和计数。
+- 邮件必须包含公司地址、退订说明等合规文案。
+
+## 9. 监控与运维
+- 暴露 Prometheus 指标：
+  - `job_alert_digest_total{status}`
+  - `job_alert_jobs_sent_total`
+  - `job_alert_scheduler_lag_seconds`
+- 日志：订阅创建/删除、调度运行结果、失败堆栈。
+- 告警：连续 3 次失败或任务延迟 > 10 分钟触发 PagerDuty 告警。
+
+## 10. 上线计划
+1. **开发阶段**
+   - 完成后端表结构、接口与调度任务；补充单元/集成测试（覆盖订阅创建、游标更新、无新增跳过等场景）。
+   - 前端实现订阅管理 UI，接入登录校验。
+2. **灰度发布**
+   - 部署到 Staging，接入测试邮件服务验证模板。
+   - 使用假数据跑一轮凌晨调度，确认只在有新增时发送。
+3. **正式发布**
+   - 先上线后端（表迁移 + 服务），默认 `status=paused` 以便观察。
+   - 打开 Feature Flag，让 10% 内部用户体验，监控指标。
+   - 一周后全量开启。
+4. **后续迭代**
+   - 支持多频率（实时/每周）、Webhook 推送等扩展。
+
+## 11. 开放问题
+- 用户时区来源：优先使用 Profile 设置，缺省时从浏览器 `Intl.DateTimeFormat().resolvedOptions().timeZone` 获取，首次创建时写入订阅表。
+- 搜索条件扩展（remote、salary）后台需与现有 `JobRepository` 查询保持一致，可在必要时新增字段与查询条件。
+- 邮件服务配额：确认 SMTP 或第三方服务每日限额，必要时排队分批发送。

--- a/vibe-jobs-aggregator/scripts/2024-08-01_job_alert_tables.sql
+++ b/vibe-jobs-aggregator/scripts/2024-08-01_job_alert_tables.sql
@@ -1,0 +1,36 @@
+-- DDL for job alert subscription feature (mirrors Flyway migration V12)
+CREATE TABLE IF NOT EXISTS job_alert_subscription (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BINARY(16) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    search_keyword VARCHAR(255) NULL,
+    company VARCHAR(255) NULL,
+    location VARCHAR(255) NULL,
+    level VARCHAR(100) NULL,
+    filters_json LONGTEXT NULL,
+    schedule_hour TINYINT NOT NULL DEFAULT 0,
+    timezone VARCHAR(64) NOT NULL DEFAULT 'Asia/Shanghai',
+    last_notified_at DATETIME NULL,
+    last_seen_cursor VARBINARY(64) NULL,
+    status ENUM('ACTIVE','PAUSED','CANCELLED') NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_job_alert_user FOREIGN KEY (user_id) REFERENCES auth_user(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_alert_user_status ON job_alert_subscription (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_job_alert_schedule ON job_alert_subscription (status, schedule_hour);
+
+CREATE TABLE IF NOT EXISTS job_alert_delivery (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    subscription_id BIGINT NOT NULL,
+    delivered_at DATETIME NOT NULL,
+    job_count INT NOT NULL DEFAULT 0,
+    job_ids LONGTEXT NULL,
+    status ENUM('SENT','SKIPPED','FAILED') NOT NULL,
+    error_message TEXT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_job_alert_delivery_subscription FOREIGN KEY (subscription_id) REFERENCES job_alert_subscription(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_alert_delivery_subscription ON job_alert_delivery (subscription_id, delivered_at DESC);

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/AggregatorApplication.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/AggregatorApplication.java
@@ -3,6 +3,7 @@ package com.vibe.jobs;
 
 import com.vibe.jobs.auth.config.EmailAuthProperties;
 import com.vibe.jobs.config.IngestionProperties;
+import com.vibe.jobs.subscription.config.JobAlertProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -12,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 @EnableAsync
-@EnableConfigurationProperties({IngestionProperties.class, EmailAuthProperties.class})
+@EnableConfigurationProperties({IngestionProperties.class, EmailAuthProperties.class, JobAlertProperties.class})
 public class AggregatorApplication {
     public static void main(String[] args) {
         System.out.println(System.getProperty("java.version"));

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/config/JobAlertEmailConfiguration.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/config/JobAlertEmailConfiguration.java
@@ -1,0 +1,27 @@
+package com.vibe.jobs.subscription.config;
+
+import com.vibe.jobs.auth.config.EmailAuthProperties;
+import com.vibe.jobs.subscription.email.ConsoleJobAlertEmailSender;
+import com.vibe.jobs.subscription.email.JobAlertEmailSender;
+import com.vibe.jobs.subscription.email.SmtpJobAlertEmailSender;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+public class JobAlertEmailConfiguration {
+
+    @Bean
+    @ConditionalOnProperty(name = "auth.email.sender", havingValue = "smtp", matchIfMissing = true)
+    public JobAlertEmailSender smtpJobAlertEmailSender(JavaMailSender mailSender, EmailAuthProperties properties) {
+        return new SmtpJobAlertEmailSender(mailSender, properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JobAlertEmailSender.class)
+    public JobAlertEmailSender consoleJobAlertEmailSender() {
+        return new ConsoleJobAlertEmailSender();
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/config/JobAlertProperties.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/config/JobAlertProperties.java
@@ -1,0 +1,72 @@
+package com.vibe.jobs.subscription.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "job-alerts")
+public class JobAlertProperties {
+    private int maxSubscriptionsPerUser = 10;
+    private int defaultScheduleHour = 0;
+    private String defaultTimezone = "Asia/Shanghai";
+    private int digestMaxJobs = 20;
+    private Duration schedulerLookback = Duration.ofHours(24);
+    private String unsubscribeSecret = "change-me";
+    private String unsubscribeBaseUrl = "https://jobs.vibecoding.com/alerts/unsubscribe";
+
+    public int getMaxSubscriptionsPerUser() {
+        return maxSubscriptionsPerUser;
+    }
+
+    public void setMaxSubscriptionsPerUser(int maxSubscriptionsPerUser) {
+        this.maxSubscriptionsPerUser = maxSubscriptionsPerUser;
+    }
+
+    public int getDefaultScheduleHour() {
+        return defaultScheduleHour;
+    }
+
+    public void setDefaultScheduleHour(int defaultScheduleHour) {
+        this.defaultScheduleHour = defaultScheduleHour;
+    }
+
+    public String getDefaultTimezone() {
+        return defaultTimezone;
+    }
+
+    public void setDefaultTimezone(String defaultTimezone) {
+        this.defaultTimezone = defaultTimezone;
+    }
+
+    public int getDigestMaxJobs() {
+        return digestMaxJobs;
+    }
+
+    public void setDigestMaxJobs(int digestMaxJobs) {
+        this.digestMaxJobs = digestMaxJobs;
+    }
+
+    public Duration getSchedulerLookback() {
+        return schedulerLookback;
+    }
+
+    public void setSchedulerLookback(Duration schedulerLookback) {
+        this.schedulerLookback = schedulerLookback;
+    }
+
+    public String getUnsubscribeSecret() {
+        return unsubscribeSecret;
+    }
+
+    public void setUnsubscribeSecret(String unsubscribeSecret) {
+        this.unsubscribeSecret = unsubscribeSecret;
+    }
+
+    public String getUnsubscribeBaseUrl() {
+        return unsubscribeBaseUrl;
+    }
+
+    public void setUnsubscribeBaseUrl(String unsubscribeBaseUrl) {
+        this.unsubscribeBaseUrl = unsubscribeBaseUrl;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertCursor.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertCursor.java
@@ -1,0 +1,37 @@
+package com.vibe.jobs.subscription.domain;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+
+public record JobAlertCursor(Instant postedAt, long jobId) {
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+    private static final Base64.Decoder DECODER = Base64.getUrlDecoder();
+
+    public String encode() {
+        String payload = postedAt.toEpochMilli() + ":" + jobId;
+        return ENCODER.encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public static JobAlertCursor decode(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return null;
+        }
+        try {
+            String decoded = new String(DECODER.decode(cursor), StandardCharsets.UTF_8);
+            String[] parts = decoded.split(":");
+            if (parts.length != 2) {
+                throw new IllegalArgumentException("Invalid cursor format");
+            }
+            long postedAtMillis = Long.parseLong(parts[0]);
+            long id = Long.parseLong(parts[1]);
+            return new JobAlertCursor(Instant.ofEpochMilli(postedAtMillis), id);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException("Invalid cursor", ex);
+        }
+    }
+
+    public static JobAlertCursor fromInstant(Instant instant) {
+        return new JobAlertCursor(instant, Long.MAX_VALUE);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertDelivery.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertDelivery.java
@@ -1,0 +1,100 @@
+package com.vibe.jobs.subscription.domain;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "job_alert_delivery", indexes = {
+        @Index(name = "idx_job_alert_delivery_subscription", columnList = "subscription_id, delivered_at DESC")
+})
+public class JobAlertDelivery {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subscription_id", nullable = false)
+    private JobAlertSubscription subscription;
+
+    @Column(name = "delivered_at", nullable = false, columnDefinition = "timestamp")
+    private Instant deliveredAt;
+
+    @Column(name = "job_count", nullable = false)
+    private int jobCount;
+
+    @Lob
+    @Column(name = "job_ids")
+    private String jobIds;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JobAlertDeliveryStatus status;
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
+    private Instant createdAt;
+
+    @PrePersist
+    void onCreate() {
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public JobAlertSubscription getSubscription() {
+        return subscription;
+    }
+
+    public void setSubscription(JobAlertSubscription subscription) {
+        this.subscription = subscription;
+    }
+
+    public Instant getDeliveredAt() {
+        return deliveredAt;
+    }
+
+    public void setDeliveredAt(Instant deliveredAt) {
+        this.deliveredAt = deliveredAt;
+    }
+
+    public int getJobCount() {
+        return jobCount;
+    }
+
+    public void setJobCount(int jobCount) {
+        this.jobCount = jobCount;
+    }
+
+    public String getJobIds() {
+        return jobIds;
+    }
+
+    public void setJobIds(String jobIds) {
+        this.jobIds = jobIds;
+    }
+
+    public JobAlertDeliveryStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(JobAlertDeliveryStatus status) {
+        this.status = status;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertDeliveryStatus.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertDeliveryStatus.java
@@ -1,0 +1,7 @@
+package com.vibe.jobs.subscription.domain;
+
+public enum JobAlertDeliveryStatus {
+    SENT,
+    SKIPPED,
+    FAILED
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertSubscription.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertSubscription.java
@@ -1,0 +1,178 @@
+package com.vibe.jobs.subscription.domain;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "job_alert_subscription", indexes = {
+        @Index(name = "idx_job_alert_user_status", columnList = "user_id, status"),
+        @Index(name = "idx_job_alert_schedule", columnList = "status, schedule_hour")
+})
+public class JobAlertSubscription {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)")
+    private UUID userId;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(name = "search_keyword")
+    private String searchKeyword;
+
+    private String company;
+
+    private String location;
+
+    private String level;
+
+    @Lob
+    @Column(name = "filters_json")
+    private String filtersJson;
+
+    @Column(name = "schedule_hour", nullable = false)
+    private int scheduleHour;
+
+    @Column(nullable = false)
+    private String timezone;
+
+    @Column(name = "last_notified_at", columnDefinition = "timestamp")
+    private Instant lastNotifiedAt;
+
+    @Column(name = "last_seen_cursor", columnDefinition = "varbinary(64)")
+    private String lastSeenCursor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private JobAlertSubscriptionStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "timestamp")
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "timestamp")
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getSearchKeyword() {
+        return searchKeyword;
+    }
+
+    public void setSearchKeyword(String searchKeyword) {
+        this.searchKeyword = searchKeyword;
+    }
+
+    public String getCompany() {
+        return company;
+    }
+
+    public void setCompany(String company) {
+        this.company = company;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public String getFiltersJson() {
+        return filtersJson;
+    }
+
+    public void setFiltersJson(String filtersJson) {
+        this.filtersJson = filtersJson;
+    }
+
+    public int getScheduleHour() {
+        return scheduleHour;
+    }
+
+    public void setScheduleHour(int scheduleHour) {
+        this.scheduleHour = scheduleHour;
+    }
+
+    public String getTimezone() {
+        return timezone;
+    }
+
+    public void setTimezone(String timezone) {
+        this.timezone = timezone;
+    }
+
+    public Instant getLastNotifiedAt() {
+        return lastNotifiedAt;
+    }
+
+    public void setLastNotifiedAt(Instant lastNotifiedAt) {
+        this.lastNotifiedAt = lastNotifiedAt;
+    }
+
+    public String getLastSeenCursor() {
+        return lastSeenCursor;
+    }
+
+    public void setLastSeenCursor(String lastSeenCursor) {
+        this.lastSeenCursor = lastSeenCursor;
+    }
+
+    public JobAlertSubscriptionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(JobAlertSubscriptionStatus status) {
+        this.status = status;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertSubscriptionStatus.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/domain/JobAlertSubscriptionStatus.java
@@ -1,0 +1,7 @@
+package com.vibe.jobs.subscription.domain;
+
+public enum JobAlertSubscriptionStatus {
+    ACTIVE,
+    PAUSED,
+    CANCELLED
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/ConsoleJobAlertEmailSender.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/ConsoleJobAlertEmailSender.java
@@ -1,0 +1,21 @@
+package com.vibe.jobs.subscription.email;
+
+import com.vibe.jobs.auth.domain.EmailAddress;
+import com.vibe.jobs.subscription.service.JobAlertDigest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ConsoleJobAlertEmailSender implements JobAlertEmailSender {
+    private static final Logger log = LoggerFactory.getLogger(ConsoleJobAlertEmailSender.class);
+
+    @Override
+    @Async("emailTaskExecutor")
+    public CompletableFuture<Void> sendDigest(EmailAddress to, JobAlertDigest digest) {
+        log.info("[ConsoleEmail] Would send job alert to {} with {} jobs", to.masked(), digest.jobs().size());
+        digest.jobs().forEach(job -> log.info(" - {} @ {} ({})", job.title(), job.company(), job.location()));
+        return CompletableFuture.completedFuture(null);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/JobAlertEmailSender.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/JobAlertEmailSender.java
@@ -1,0 +1,10 @@
+package com.vibe.jobs.subscription.email;
+
+import com.vibe.jobs.auth.domain.EmailAddress;
+import com.vibe.jobs.subscription.service.JobAlertDigest;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface JobAlertEmailSender {
+    CompletableFuture<Void> sendDigest(EmailAddress to, JobAlertDigest digest);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/SmtpJobAlertEmailSender.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/email/SmtpJobAlertEmailSender.java
@@ -1,0 +1,86 @@
+package com.vibe.jobs.subscription.email;
+
+import com.vibe.jobs.auth.config.EmailAuthProperties;
+import com.vibe.jobs.auth.domain.EmailAddress;
+import com.vibe.jobs.subscription.service.JobAlertDigest;
+import jakarta.mail.internet.MimeMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+
+public class SmtpJobAlertEmailSender implements JobAlertEmailSender {
+    private static final Logger log = LoggerFactory.getLogger(SmtpJobAlertEmailSender.class);
+
+    private final JavaMailSender mailSender;
+    private final EmailAuthProperties properties;
+
+    public SmtpJobAlertEmailSender(JavaMailSender mailSender, EmailAuthProperties properties) {
+        this.mailSender = mailSender;
+        this.properties = properties;
+    }
+
+    @Override
+    @Async("emailTaskExecutor")
+    public CompletableFuture<Void> sendDigest(EmailAddress to, JobAlertDigest digest) {
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, StandardCharsets.UTF_8.name());
+            helper.setTo(to.value());
+            String from = resolveFromAddress();
+            if (from != null && !from.isBlank()) {
+                helper.setFrom(from);
+            }
+            helper.setSubject(buildSubject(digest));
+            helper.setText(buildBody(digest), true);
+            mailSender.send(message);
+            log.info("Sent job alert digest email to {}", to.masked());
+            return CompletableFuture.completedFuture(null);
+        } catch (Exception ex) {
+            log.error("Failed to send job alert email to {}", to.masked(), ex);
+            return CompletableFuture.failedFuture(ex);
+        }
+    }
+
+    private String resolveFromAddress() {
+        if (properties.getFromAddress() != null && !properties.getFromAddress().isBlank()) {
+            return properties.getFromAddress();
+        }
+        if (mailSender instanceof JavaMailSenderImpl impl) {
+            return impl.getUsername();
+        }
+        return null;
+    }
+
+    private String buildSubject(JobAlertDigest digest) {
+        return String.format("【Elaine Jobs】%d 个新的%s职位", digest.jobs().size(), digest.subscriptionSummary());
+    }
+
+    private String buildBody(JobAlertDigest digest) {
+        StringBuilder html = new StringBuilder();
+        html.append("<p>以下是根据您的订阅条件“").append(digest.subscriptionSummary()).append("”筛选出的最新职位：</p>");
+        html.append("<ul>");
+        digest.jobs().forEach(job -> html.append("<li><strong>")
+                .append(job.title())
+                .append("</strong> - ")
+                .append(job.company())
+                .append("（")
+                .append(job.location() == null ? "不限地点" : job.location())
+                .append("，发布于 ")
+                .append(job.postedAt())
+                .append("） <a href=\"")
+                .append(job.url())
+                .append("\">查看职位</a></li>"));
+        html.append("</ul>");
+        html.append("<p>如需取消订阅，请点击：<a href=\"")
+                .append(digest.unsubscribeUrl())
+                .append("\">取消订阅</a></p>");
+        html.append("<p>感谢使用 Elaine Jobs。</p>");
+        return html.toString();
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/repo/JobAlertDeliveryRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/repo/JobAlertDeliveryRepository.java
@@ -1,0 +1,11 @@
+package com.vibe.jobs.subscription.repo;
+
+import com.vibe.jobs.subscription.domain.JobAlertDelivery;
+import com.vibe.jobs.subscription.domain.JobAlertSubscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface JobAlertDeliveryRepository extends JpaRepository<JobAlertDelivery, Long> {
+    Optional<JobAlertDelivery> findTopBySubscriptionOrderByDeliveredAtDesc(JobAlertSubscription subscription);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/repo/JobAlertSubscriptionRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/repo/JobAlertSubscriptionRepository.java
@@ -1,0 +1,19 @@
+package com.vibe.jobs.subscription.repo;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscription;
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface JobAlertSubscriptionRepository extends JpaRepository<JobAlertSubscription, Long> {
+    List<JobAlertSubscription> findByUserId(UUID userId);
+
+    long countByUserIdAndStatusNot(UUID userId, JobAlertSubscriptionStatus status);
+
+    Optional<JobAlertSubscription> findByIdAndUserId(Long id, UUID userId);
+
+    List<JobAlertSubscription> findByStatus(JobAlertSubscriptionStatus status);
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/CreateJobAlertCommand.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/CreateJobAlertCommand.java
@@ -1,0 +1,12 @@
+package com.vibe.jobs.subscription.service;
+
+import java.util.Map;
+
+public record CreateJobAlertCommand(String keyword,
+                                    String company,
+                                    String location,
+                                    String level,
+                                    Map<String, Object> filters,
+                                    Integer scheduleHour,
+                                    String timezone) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertDigest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertDigest.java
@@ -1,0 +1,16 @@
+package com.vibe.jobs.subscription.service;
+
+import java.time.Instant;
+import java.util.List;
+
+public record JobAlertDigest(String subscriptionSummary,
+                             String unsubscribeUrl,
+                             List<JobItem> jobs) {
+
+    public record JobItem(Long id,
+                          String title,
+                          String company,
+                          String location,
+                          Instant postedAt,
+                          String url) {}
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertScheduler.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertScheduler.java
@@ -1,0 +1,48 @@
+package com.vibe.jobs.subscription.service;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscription;
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+import com.vibe.jobs.subscription.repo.JobAlertSubscriptionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class JobAlertScheduler {
+    private static final Logger log = LoggerFactory.getLogger(JobAlertScheduler.class);
+
+    private final JobAlertSubscriptionRepository subscriptionRepository;
+    private final JobAlertSubscriptionService subscriptionService;
+    private final Clock clock;
+
+    public JobAlertScheduler(JobAlertSubscriptionRepository subscriptionRepository,
+                             JobAlertSubscriptionService subscriptionService,
+                             Optional<Clock> clock) {
+        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionService = subscriptionService;
+        this.clock = clock.orElse(Clock.systemUTC());
+    }
+
+    @Scheduled(cron = "0 */15 * * * *")
+    @Transactional
+    public void dispatchDigests() {
+        Instant now = Instant.now(clock);
+        List<JobAlertSubscription> activeSubscriptions = subscriptionRepository.findByStatus(JobAlertSubscriptionStatus.ACTIVE);
+        activeSubscriptions.stream()
+                .filter(subscription -> subscriptionService.shouldRun(subscription, now))
+                .forEach(subscription -> {
+                    try {
+                        subscriptionService.processSubscription(subscription);
+                    } catch (Exception ex) {
+                        log.error("Failed to process subscription {}", subscription.getId(), ex);
+                    }
+                });
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertSubscriptionService.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/JobAlertSubscriptionService.java
@@ -1,0 +1,313 @@
+package com.vibe.jobs.subscription.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vibe.jobs.auth.domain.EmailAddress;
+import com.vibe.jobs.domain.Job;
+import com.vibe.jobs.repo.JobRepository;
+import com.vibe.jobs.subscription.config.JobAlertProperties;
+import com.vibe.jobs.subscription.domain.JobAlertCursor;
+import com.vibe.jobs.subscription.domain.JobAlertDelivery;
+import com.vibe.jobs.subscription.domain.JobAlertDeliveryStatus;
+import com.vibe.jobs.subscription.domain.JobAlertSubscription;
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+import com.vibe.jobs.subscription.email.JobAlertEmailSender;
+import com.vibe.jobs.subscription.repo.JobAlertDeliveryRepository;
+import com.vibe.jobs.subscription.repo.JobAlertSubscriptionRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class JobAlertSubscriptionService {
+    private final JobAlertSubscriptionRepository subscriptionRepository;
+    private final JobAlertDeliveryRepository deliveryRepository;
+    private final JobRepository jobRepository;
+    private final JobAlertEmailSender emailSender;
+    private final JobAlertProperties properties;
+    private final Clock clock;
+    private final ObjectMapper objectMapper;
+
+    public JobAlertSubscriptionService(JobAlertSubscriptionRepository subscriptionRepository,
+                                       JobAlertDeliveryRepository deliveryRepository,
+                                       JobRepository jobRepository,
+                                       JobAlertEmailSender emailSender,
+                                       JobAlertProperties properties,
+                                       Optional<Clock> clock,
+                                       ObjectMapper objectMapper) {
+        this.subscriptionRepository = subscriptionRepository;
+        this.deliveryRepository = deliveryRepository;
+        this.jobRepository = jobRepository;
+        this.emailSender = emailSender;
+        this.properties = properties;
+        this.clock = clock.orElse(Clock.systemUTC());
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional(readOnly = true)
+    public List<JobAlertSubscription> listFor(UUID userId) {
+        return subscriptionRepository.findByUserId(userId);
+    }
+
+    public JobAlertSubscription create(UUID userId, String email, CreateJobAlertCommand command) {
+        enforceLimit(userId);
+        JobAlertSubscription subscription = new JobAlertSubscription();
+        subscription.setUserId(userId);
+        subscription.setEmail(email);
+        subscription.setSearchKeyword(trimToNull(command.keyword()));
+        subscription.setCompany(trimToNull(command.company()));
+        subscription.setLocation(trimToNull(command.location()));
+        subscription.setLevel(trimToNull(command.level()));
+        subscription.setFiltersJson(serializeFilters(command.filters()));
+        subscription.setScheduleHour(normalizeHour(command.scheduleHour()));
+        subscription.setTimezone(resolveTimezone(command.timezone()));
+        subscription.setStatus(JobAlertSubscriptionStatus.ACTIVE);
+        subscription.setLastSeenCursor(JobAlertCursor.fromInstant(Instant.now(clock)).encode());
+        return subscriptionRepository.save(subscription);
+    }
+
+    public JobAlertSubscription update(UUID userId, Long id, UpdateJobAlertCommand command) {
+        JobAlertSubscription subscription = subscriptionRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new NoSuchElementException("Subscription not found"));
+        if (command.keyword() != null) subscription.setSearchKeyword(trimToNull(command.keyword()));
+        if (command.company() != null) subscription.setCompany(trimToNull(command.company()));
+        if (command.location() != null) subscription.setLocation(trimToNull(command.location()));
+        if (command.level() != null) subscription.setLevel(trimToNull(command.level()));
+        if (command.filters() != null) subscription.setFiltersJson(serializeFilters(command.filters()));
+        if (command.scheduleHour() != null) subscription.setScheduleHour(normalizeHour(command.scheduleHour()));
+        if (command.timezone() != null) subscription.setTimezone(resolveTimezone(command.timezone()));
+        if (command.status() != null) subscription.setStatus(command.status());
+        return subscriptionRepository.save(subscription);
+    }
+
+    public void cancel(UUID userId, Long id) {
+        JobAlertSubscription subscription = requireOwnedSubscription(userId, id);
+        subscription.setStatus(JobAlertSubscriptionStatus.CANCELLED);
+        subscriptionRepository.save(subscription);
+    }
+
+    public void unsubscribe(Long subscriptionId, String token) {
+        JobAlertSubscription subscription = subscriptionRepository.findById(subscriptionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Subscription not found"));
+        if (!isValidToken(subscription, token)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid unsubscribe token");
+        }
+        subscription.setStatus(JobAlertSubscriptionStatus.CANCELLED);
+        subscriptionRepository.save(subscription);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<JobAlertSubscription> findById(Long id) {
+        return subscriptionRepository.findById(id);
+    }
+
+    public void triggerTest(UUID userId, Long subscriptionId) {
+        JobAlertSubscription subscription = requireOwnedSubscription(userId, subscriptionId);
+        var digest = new JobAlertDigest(buildSummary(subscription),
+                buildUnsubscribeUrl(subscription),
+                List.of());
+        emailSender.sendDigest(new EmailAddress(subscription.getEmail()), digest);
+    }
+
+    public boolean shouldRun(JobAlertSubscription subscription, Instant now) {
+        if (subscription.getStatus() != JobAlertSubscriptionStatus.ACTIVE) {
+            return false;
+        }
+        ZoneId zone = ZoneId.of(resolveTimezone(subscription.getTimezone()));
+        ZonedDateTime localNow = now.atZone(zone);
+        if (localNow.getHour() != subscription.getScheduleHour()) {
+            return false;
+        }
+        Optional<JobAlertDelivery> lastDelivery = deliveryRepository.findTopBySubscriptionOrderByDeliveredAtDesc(subscription);
+        if (lastDelivery.isEmpty()) {
+            return true;
+        }
+        JobAlertDelivery delivery = lastDelivery.get();
+        if (delivery.getStatus() == JobAlertDeliveryStatus.FAILED) {
+            Instant nextAttempt = delivery.getDeliveredAt().plus(Duration.ofMinutes(15));
+            return nextAttempt.isBefore(now) || nextAttempt.equals(now);
+        }
+        ZonedDateTime lastLocal = delivery.getDeliveredAt().atZone(zone);
+        return !lastLocal.toLocalDate().isEqual(localNow.toLocalDate());
+    }
+
+    public void processSubscription(JobAlertSubscription subscription) {
+        Instant now = Instant.now(clock);
+        JobAlertCursor cursor = JobAlertCursor.decode(subscription.getLastSeenCursor());
+        Instant sincePostedAt = cursor != null ? cursor.postedAt() : now.minus(properties.getSchedulerLookback());
+        Long sinceId = cursor != null ? cursor.jobId() : 0L;
+
+        var pageable = PageRequest.of(0, properties.getDigestMaxJobs(), Sort.by(Sort.Direction.ASC, "postedAt", "id"));
+        List<Job> jobs = jobRepository.findNewJobsForAlert(
+                subscription.getSearchKeyword(),
+                subscription.getCompany(),
+                subscription.getLocation(),
+                subscription.getLevel(),
+                sincePostedAt,
+                sinceId,
+                pageable
+        );
+
+        if (jobs.isEmpty()) {
+            recordDelivery(subscription, now, JobAlertDeliveryStatus.SKIPPED, List.of(), null);
+            subscription.setLastSeenCursor(JobAlertCursor.fromInstant(now).encode());
+            subscriptionRepository.save(subscription);
+            return;
+        }
+
+        Job lastJob = jobs.get(jobs.size() - 1);
+        JobAlertCursor newCursor = new JobAlertCursor(lastJob.getPostedAt(), lastJob.getId());
+
+        JobAlertDigest digest = new JobAlertDigest(
+                buildSummary(subscription),
+                buildUnsubscribeUrl(subscription),
+                jobs.stream().map(job -> new JobAlertDigest.JobItem(
+                        job.getId(),
+                        job.getTitle(),
+                        job.getCompany(),
+                        job.getLocation(),
+                        job.getPostedAt(),
+                        job.getUrl()
+                )).collect(Collectors.toList())
+        );
+
+        try {
+            emailSender.sendDigest(new EmailAddress(subscription.getEmail()), digest).join();
+            subscription.setLastNotifiedAt(now);
+            subscription.setLastSeenCursor(newCursor.encode());
+            subscriptionRepository.save(subscription);
+            recordDelivery(subscription, now, JobAlertDeliveryStatus.SENT, jobs.stream().map(Job::getId).toList(), null);
+        } catch (Exception ex) {
+            recordDelivery(subscription, now, JobAlertDeliveryStatus.FAILED, jobs.stream().map(Job::getId).toList(), ex.getMessage());
+        }
+    }
+
+    private void recordDelivery(JobAlertSubscription subscription,
+                                 Instant deliveredAt,
+                                 JobAlertDeliveryStatus status,
+                                 List<Long> jobIds,
+                                 String errorMessage) {
+        JobAlertDelivery delivery = new JobAlertDelivery();
+        delivery.setSubscription(subscription);
+        delivery.setDeliveredAt(deliveredAt);
+        delivery.setStatus(status);
+        delivery.setJobCount(jobIds.size());
+        delivery.setJobIds(serializeJobIds(jobIds));
+        delivery.setErrorMessage(errorMessage);
+        deliveryRepository.save(delivery);
+    }
+
+    private String serializeJobIds(List<Long> jobIds) {
+        try {
+            return objectMapper.writeValueAsString(jobIds);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize job ids", e);
+        }
+    }
+
+    private void enforceLimit(UUID userId) {
+        long count = subscriptionRepository.countByUserIdAndStatusNot(userId, JobAlertSubscriptionStatus.CANCELLED);
+        if (count >= properties.getMaxSubscriptionsPerUser()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Subscription limit exceeded");
+        }
+    }
+
+    private JobAlertSubscription requireOwnedSubscription(UUID userId, Long id) {
+        return subscriptionRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Subscription not found"));
+    }
+
+    private int normalizeHour(Integer hour) {
+        if (hour == null) {
+            return properties.getDefaultScheduleHour();
+        }
+        int value = hour % 24;
+        return value < 0 ? value + 24 : value;
+    }
+
+    private String resolveTimezone(String timezone) {
+        if (timezone == null || timezone.isBlank()) {
+            return properties.getDefaultTimezone();
+        }
+        try {
+            ZoneId.of(timezone);
+            return timezone;
+        } catch (Exception ex) {
+            return properties.getDefaultTimezone();
+        }
+    }
+
+    private String serializeFilters(Map<String, Object> filters) {
+        if (filters == null || filters.isEmpty()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(filters);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Invalid filters", e);
+        }
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    public String buildUnsubscribeUrl(JobAlertSubscription subscription) {
+        String base = properties.getUnsubscribeBaseUrl();
+        if (base == null || base.isBlank()) {
+            return "#";
+        }
+        String separator = base.contains("?") ? "&" : "?";
+        return base + separator + "id=" + subscription.getId() + "&token=" + generateToken(subscription);
+    }
+
+    private String buildSummary(JobAlertSubscription subscription) {
+        List<String> parts = new ArrayList<>();
+        if (subscription.getSearchKeyword() != null) parts.add(subscription.getSearchKeyword());
+        if (subscription.getCompany() != null) parts.add(subscription.getCompany());
+        if (subscription.getLocation() != null) parts.add(subscription.getLocation());
+        if (parts.isEmpty()) {
+            return "全部职位";
+        }
+        return String.join(" · ", parts);
+    }
+
+    private String generateToken(JobAlertSubscription subscription) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(properties.getUnsubscribeSecret().getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            String payload = subscription.getUserId() + ":" + subscription.getId();
+            byte[] signature = mac.doFinal(payload.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(signature);
+        } catch (Exception ex) {
+            throw new IllegalStateException("Failed to generate token", ex);
+        }
+    }
+
+    private boolean isValidToken(JobAlertSubscription subscription, String token) {
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+        String expected = generateToken(subscription);
+        return Objects.equals(expected, token);
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/UpdateJobAlertCommand.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/subscription/service/UpdateJobAlertCommand.java
@@ -1,0 +1,15 @@
+package com.vibe.jobs.subscription.service;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+
+import java.util.Map;
+
+public record UpdateJobAlertCommand(String keyword,
+                                    String company,
+                                    String location,
+                                    String level,
+                                    Map<String, Object> filters,
+                                    Integer scheduleHour,
+                                    String timezone,
+                                    JobAlertSubscriptionStatus status) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserPrincipal.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserPrincipal.java
@@ -1,0 +1,5 @@
+package com.vibe.jobs.web.session;
+
+import java.util.UUID;
+
+public record UserPrincipal(UUID userId, String email) {}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserPrincipalArgumentResolver.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserPrincipalArgumentResolver.java
@@ -1,0 +1,23 @@
+package com.vibe.jobs.web.session;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class UserPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(UserPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Object principal = webRequest.getAttribute(UserSessionInterceptor.USER_PRINCIPAL_ATTR, NativeWebRequest.SCOPE_REQUEST);
+        if (principal == null) {
+            throw new IllegalStateException("Missing user principal");
+        }
+        return principal;
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserSessionInterceptor.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserSessionInterceptor.java
@@ -1,0 +1,70 @@
+package com.vibe.jobs.web.session;
+
+import com.vibe.jobs.auth.application.EmailAuthService;
+import com.vibe.jobs.auth.application.EmailAuthService.AuthenticatedUser;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class UserSessionInterceptor implements HandlerInterceptor {
+    public static final String USER_PRINCIPAL_ATTR = UserPrincipal.class.getName();
+
+    private final EmailAuthService emailAuthService;
+
+    public UserSessionInterceptor(EmailAuthService emailAuthService) {
+        this.emailAuthService = emailAuthService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        String token = resolveToken(request);
+        if (token == null) {
+            reject(response, HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+        Optional<AuthenticatedUser> resolved = emailAuthService.resolveSession(token);
+        if (resolved.isEmpty()) {
+            reject(response, HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+        AuthenticatedUser user = resolved.get();
+        request.setAttribute(USER_PRINCIPAL_ATTR, new UserPrincipal(user.userId(), user.email()));
+        return true;
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String header = request.getHeader("X-Session-Token");
+        if (header != null && !header.isBlank()) {
+            return header.trim();
+        }
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String bearer = authHeader.substring(7).trim();
+            if (!bearer.isEmpty()) {
+                return bearer;
+            }
+        }
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if (cookie != null && "vj_session".equals(cookie.getName())) {
+                    String value = cookie.getValue();
+                    if (value != null && !value.isBlank()) {
+                        return value.trim();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void reject(HttpServletResponse response, HttpStatus status) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.getWriter().write("{\"code\":\"UNAUTHORIZED\"}");
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserWebMvcConfigurer.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/session/UserWebMvcConfigurer.java
@@ -1,0 +1,31 @@
+package com.vibe.jobs.web.session;
+
+import com.vibe.jobs.auth.application.EmailAuthService;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class UserWebMvcConfigurer implements WebMvcConfigurer {
+
+    private final EmailAuthService emailAuthService;
+
+    public UserWebMvcConfigurer(EmailAuthService emailAuthService) {
+        this.emailAuthService = emailAuthService;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new UserSessionInterceptor(emailAuthService))
+                .addPathPatterns("/subscriptions/**")
+                .excludePathPatterns("/subscriptions/*/unsubscribe");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserPrincipalArgumentResolver());
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/JobSubscriptionController.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/JobSubscriptionController.java
@@ -1,0 +1,114 @@
+package com.vibe.jobs.web.subscription;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscription;
+import com.vibe.jobs.subscription.service.CreateJobAlertCommand;
+import com.vibe.jobs.subscription.service.JobAlertSubscriptionService;
+import com.vibe.jobs.subscription.service.UpdateJobAlertCommand;
+import com.vibe.jobs.web.session.UserPrincipal;
+import com.vibe.jobs.web.subscription.dto.CreateSubscriptionRequest;
+import com.vibe.jobs.web.subscription.dto.SubscriptionResponse;
+import com.vibe.jobs.web.subscription.dto.UnsubscribeRequest;
+import com.vibe.jobs.web.subscription.dto.UpdateSubscriptionRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/subscriptions")
+@CrossOrigin(origins = "*")
+public class JobSubscriptionController {
+
+    private final JobAlertSubscriptionService subscriptionService;
+
+    public JobSubscriptionController(JobAlertSubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    @GetMapping
+    public List<SubscriptionResponse> list(UserPrincipal principal) {
+        return subscriptionService.listFor(principal.userId())
+                .stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SubscriptionResponse create(UserPrincipal principal,
+                                       @Valid @RequestBody CreateSubscriptionRequest request) {
+        JobAlertSubscription subscription = subscriptionService.create(
+                principal.userId(),
+                principal.email(),
+                new CreateJobAlertCommand(
+                        request.keyword(),
+                        request.company(),
+                        request.location(),
+                        request.level(),
+                        request.filters(),
+                        request.scheduleHour(),
+                        request.timezone()
+                )
+        );
+        return toResponse(subscription);
+    }
+
+    @PatchMapping("/{id}")
+    public SubscriptionResponse update(UserPrincipal principal,
+                                       @PathVariable Long id,
+                                       @RequestBody UpdateSubscriptionRequest request) {
+        JobAlertSubscription updated = subscriptionService.update(
+                principal.userId(),
+                id,
+                new UpdateJobAlertCommand(
+                        request.keyword(),
+                        request.company(),
+                        request.location(),
+                        request.level(),
+                        request.filters(),
+                        request.scheduleHour(),
+                        request.timezone(),
+                        request.status()
+                )
+        );
+        return toResponse(updated);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(UserPrincipal principal, @PathVariable Long id) {
+        subscriptionService.cancel(principal.userId(), id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/test")
+    public ResponseEntity<Void> triggerTest(UserPrincipal principal, @PathVariable Long id) {
+        subscriptionService.triggerTest(principal.userId(), id);
+        return ResponseEntity.accepted().build();
+    }
+
+    @PostMapping("/{id}/unsubscribe")
+    public ResponseEntity<Void> unsubscribe(@PathVariable Long id,
+                                            @Valid @RequestBody UnsubscribeRequest request) {
+        subscriptionService.unsubscribe(id, request.token());
+        return ResponseEntity.noContent().build();
+    }
+
+    private SubscriptionResponse toResponse(JobAlertSubscription subscription) {
+        return new SubscriptionResponse(
+                subscription.getId(),
+                subscription.getSearchKeyword(),
+                subscription.getCompany(),
+                subscription.getLocation(),
+                subscription.getLevel(),
+                subscription.getFiltersJson(),
+                subscription.getScheduleHour(),
+                subscription.getTimezone(),
+                subscription.getStatus(),
+                subscription.getLastNotifiedAt(),
+                subscription.getCreatedAt()
+        );
+    }
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/CreateSubscriptionRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/CreateSubscriptionRequest.java
@@ -1,0 +1,11 @@
+package com.vibe.jobs.web.subscription.dto;
+
+import java.util.Map;
+public record CreateSubscriptionRequest(String keyword,
+                                        String company,
+                                        String location,
+                                        String level,
+                                        Map<String, Object> filters,
+                                        Integer scheduleHour,
+                                        String timezone) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/SubscriptionResponse.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/SubscriptionResponse.java
@@ -1,0 +1,18 @@
+package com.vibe.jobs.web.subscription.dto;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+
+import java.time.Instant;
+
+public record SubscriptionResponse(Long id,
+                                   String keyword,
+                                   String company,
+                                   String location,
+                                   String level,
+                                   String filters,
+                                   Integer scheduleHour,
+                                   String timezone,
+                                   JobAlertSubscriptionStatus status,
+                                   Instant lastNotifiedAt,
+                                   Instant createdAt) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/UnsubscribeRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/UnsubscribeRequest.java
@@ -1,0 +1,6 @@
+package com.vibe.jobs.web.subscription.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UnsubscribeRequest(@NotBlank String token) {
+}

--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/UpdateSubscriptionRequest.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/web/subscription/dto/UpdateSubscriptionRequest.java
@@ -1,0 +1,15 @@
+package com.vibe.jobs.web.subscription.dto;
+
+import com.vibe.jobs.subscription.domain.JobAlertSubscriptionStatus;
+
+import java.util.Map;
+
+public record UpdateSubscriptionRequest(String keyword,
+                                        String company,
+                                        String location,
+                                        String level,
+                                        Map<String, Object> filters,
+                                        Integer scheduleHour,
+                                        String timezone,
+                                        JobAlertSubscriptionStatus status) {
+}

--- a/vibe-jobs-aggregator/src/main/resources/db/migration/V12__create_job_alert_tables.sql
+++ b/vibe-jobs-aggregator/src/main/resources/db/migration/V12__create_job_alert_tables.sql
@@ -1,0 +1,35 @@
+CREATE TABLE job_alert_subscription (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    user_id BINARY(16) NOT NULL,
+    email VARCHAR(255) NOT NULL,
+    search_keyword VARCHAR(255) NULL,
+    company VARCHAR(255) NULL,
+    location VARCHAR(255) NULL,
+    level VARCHAR(100) NULL,
+    filters_json LONGTEXT NULL,
+    schedule_hour TINYINT NOT NULL DEFAULT 0,
+    timezone VARCHAR(64) NOT NULL DEFAULT 'Asia/Shanghai',
+    last_notified_at DATETIME NULL,
+    last_seen_cursor VARBINARY(64) NULL,
+    status ENUM('ACTIVE','PAUSED','CANCELLED') NOT NULL DEFAULT 'ACTIVE',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_job_alert_user FOREIGN KEY (user_id) REFERENCES auth_user(id)
+);
+
+CREATE INDEX idx_job_alert_user_status ON job_alert_subscription (user_id, status);
+CREATE INDEX idx_job_alert_schedule ON job_alert_subscription (status, schedule_hour);
+
+CREATE TABLE job_alert_delivery (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    subscription_id BIGINT NOT NULL,
+    delivered_at DATETIME NOT NULL,
+    job_count INT NOT NULL DEFAULT 0,
+    job_ids LONGTEXT NULL,
+    status ENUM('SENT','SKIPPED','FAILED') NOT NULL,
+    error_message TEXT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_job_alert_delivery_subscription FOREIGN KEY (subscription_id) REFERENCES job_alert_subscription(id)
+);
+
+CREATE INDEX idx_job_alert_delivery_subscription ON job_alert_delivery (subscription_id, delivered_at DESC);

--- a/vibe-jobs-view/app/api/subscriptions/[id]/route.ts
+++ b/vibe-jobs-view/app/api/subscriptions/[id]/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+function resolveSessionToken(req: NextRequest): string | undefined {
+  const header = req.headers.get('x-session-token');
+  if (header && header.trim().length > 0) {
+    return header.trim();
+  }
+  const bearer = req.headers.get('authorization');
+  if (bearer?.startsWith('Bearer ')) {
+    const token = bearer.substring(7).trim();
+    if (token) return token;
+  }
+  const cookieToken = cookies().get('vj_session')?.value;
+  if (cookieToken && cookieToken.trim().length > 0) {
+    return cookieToken.trim();
+  }
+  return undefined;
+}
+
+async function forward(req: NextRequest, init?: RequestInit) {
+  const base = resolveBackendBase(req);
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
+  }
+  const upstream = buildBackendUrl(base, `/subscriptions/${req.nextUrl.pathname.split('/').pop()}`);
+  const token = resolveSessionToken(req);
+  const headers: HeadersInit = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+  };
+  if (token) {
+    headers['x-session-token'] = token;
+    headers['authorization'] = `Bearer ${token}`;
+  }
+  const response = await fetch(upstream, {
+    method: req.method,
+    headers,
+    body: init?.body,
+    cache: 'no-store',
+  });
+  const text = await response.text();
+  if (text) {
+    try {
+      const json = JSON.parse(text);
+      return NextResponse.json(json, { status: response.status });
+    } catch {
+      return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend.', raw: text }, { status: 502 });
+    }
+  }
+  return new NextResponse(null, { status: response.status });
+}
+
+export async function PATCH(req: NextRequest) {
+  const body = await req.text();
+  return forward(req, { body });
+}
+
+export async function DELETE(req: NextRequest) {
+  return forward(req);
+}

--- a/vibe-jobs-view/app/api/subscriptions/[id]/unsubscribe/route.ts
+++ b/vibe-jobs-view/app/api/subscriptions/[id]/unsubscribe/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+export async function POST(req: NextRequest) {
+  const base = resolveBackendBase(req);
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
+  }
+  const segments = req.nextUrl.pathname.split('/');
+  const id = segments[segments.length - 2];
+  const upstream = buildBackendUrl(base, `/subscriptions/${id}/unsubscribe`);
+  const body = await req.text();
+  const response = await fetch(upstream, {
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+    },
+    body,
+    cache: 'no-store',
+  });
+  const text = await response.text();
+  if (text) {
+    try {
+      const json = JSON.parse(text);
+      return NextResponse.json(json, { status: response.status });
+    } catch {
+      return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend.', raw: text }, { status: 502 });
+    }
+  }
+  return new NextResponse(null, { status: response.status });
+}

--- a/vibe-jobs-view/app/api/subscriptions/route.ts
+++ b/vibe-jobs-view/app/api/subscriptions/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { buildBackendUrl, resolveBackendBase } from '@/lib/backend';
+
+function resolveSessionToken(req: NextRequest): string | undefined {
+  const header = req.headers.get('x-session-token');
+  if (header && header.trim().length > 0) {
+    return header.trim();
+  }
+  const bearer = req.headers.get('authorization');
+  if (bearer?.startsWith('Bearer ')) {
+    const token = bearer.substring(7).trim();
+    if (token) return token;
+  }
+  const cookieToken = cookies().get('vj_session')?.value;
+  if (cookieToken && cookieToken.trim().length > 0) {
+    return cookieToken.trim();
+  }
+  return undefined;
+}
+
+async function forwardToBackend(req: NextRequest, init?: RequestInit) {
+  const base = resolveBackendBase(req);
+  if (!base) {
+    return NextResponse.json({ code: 'CONFIG_ERROR', message: 'Backend base URL not configured.' }, { status: 500 });
+  }
+  const upstream = buildBackendUrl(base, '/subscriptions');
+  const token = resolveSessionToken(req);
+  const headers: HeadersInit = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+  };
+  if (token) {
+    headers['x-session-token'] = token;
+    headers['authorization'] = `Bearer ${token}`;
+  }
+  const response = await fetch(upstream, {
+    method: req.method,
+    headers,
+    body: init?.body,
+    cache: 'no-store',
+  });
+  const text = await response.text();
+  try {
+    const json = text ? JSON.parse(text) : null;
+    return NextResponse.json(json, { status: response.status });
+  } catch {
+    return NextResponse.json({ code: 'UPSTREAM_ERROR', message: 'Unexpected response from backend.', raw: text }, { status: 502 });
+  }
+}
+
+export async function GET(req: NextRequest) {
+  return forwardToBackend(req);
+}
+
+export async function POST(req: NextRequest) {
+  const body = await req.text();
+  return forwardToBackend(req, { body });
+}


### PR DESCRIPTION
## Summary
- introduce job alert subscription entities, repositories, services, scheduler, and REST endpoints with session enforcement and configurable email delivery support
- add schema migration and companion SQL script for subscription and delivery tracking tables
- wire Next.js API proxy routes and search page messaging to create subscriptions through the authenticated backend

## Testing
- mvn -q test *(fails: unable to download Spring Boot parent POM due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e26dbc892c8328b0c45141be6a445c