### PR TITLE
Clone WebClient builder before adding detail headers

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/DefaultCrawlerParserEngine.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/crawler/infrastructure/parser/DefaultCrawlerParserEngine.java
@@ -208,6 +208,7 @@ public class DefaultCrawlerParserEngine implements CrawlerParserEngine {
     private String fetchDetailPage(String url) {
         try {
             WebClient client = webClientBuilder
+                    .clone()
                     .defaultHeader(HttpHeaders.ACCEPT, MediaType.TEXT_HTML_VALUE)
                     .defaultHeader(HttpHeaders.USER_AGENT, getRandomUserAgent())
                     .build();


### PR DESCRIPTION
## Summary
- clone the shared WebClient builder before setting detail fetch headers to avoid mutating the shared instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e555217a10832888e529281d71e835