### PR TITLE
Fix keyword search query to use keyword parameter

### DIFF
--- a/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/repo/JobRepository.java
+++ b/vibe-jobs-aggregator/src/main/java/com/vibe/jobs/repo/JobRepository.java
@@ -20,10 +20,10 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     @Query("""
         select j from Job j
         where j.deleted = false
-        and (:q is null or 
-               lower(j.title) like lower(concat('%',:q,'%')) or 
-               lower(j.company) like lower(concat('%',:company,'%')) or 
-               lower(j.location) like lower(concat('%',:location,'%')) or 
+        and (:q is null or
+               lower(j.title) like lower(concat('%',:q,'%')) or
+               lower(j.company) like lower(concat('%',:q,'%')) or
+               lower(j.location) like lower(concat('%',:q,'%')) or
                exists (select t from j.tags t where lower(t) like lower(concat('%',:q,'%')))
             )
         and (:company is null or lower(j.company) like lower(concat('%',:company,'%')))
@@ -48,10 +48,10 @@ public interface JobRepository extends JpaRepository<Job, Long> {
     @Query("""
         select count(j) from Job j
         where j.deleted = false
-        and (:q is null or 
-               lower(j.title) like lower(concat('%',:q,'%')) or 
-               lower(j.company) like lower(concat('%',:company,'%')) or 
-               lower(j.location) like lower(concat('%',:location,'%')) or 
+        and (:q is null or
+               lower(j.title) like lower(concat('%',:q,'%')) or
+               lower(j.company) like lower(concat('%',:q,'%')) or
+               lower(j.location) like lower(concat('%',:q,'%')) or
                exists (select t from j.tags t where lower(t) like lower(concat('%',:q,'%')))
             )
         and (:company is null or lower(j.company) like lower(concat('%',:company,'%')))


### PR DESCRIPTION
## Summary
- ensure the keyword search clause always uses the user keyword when matching title, company, and location fields

## Testing
- mvn test *(fails: unable to download dependencies from Maven Central in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e618669af08328a149e3a6d45f43b2